### PR TITLE
chore: add RLS policies for all tables (#4)

### DIFF
--- a/supabase/migrations/0001_rls_policies.sql
+++ b/supabase/migrations/0001_rls_policies.sql
@@ -1,0 +1,202 @@
+-- ============================================================
+-- Row Level Security (RLS) — workspace isolation policies
+--
+-- All access goes through workspace_members.
+-- Never user_id = auth.uid() directly on content tables.
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- Helper functions (SECURITY DEFINER to bypass RLS on
+-- workspace_members and avoid self-referencing policy issues)
+-- ------------------------------------------------------------
+
+-- Returns TRUE if the current user is an accepted member of the workspace.
+CREATE OR REPLACE FUNCTION public.is_workspace_member(ws_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.workspace_members
+    WHERE workspace_id = ws_id
+      AND user_id = (SELECT auth.uid())
+      AND accepted_at IS NOT NULL
+  );
+$$;
+
+-- Returns TRUE if the current user is an owner or admin of the workspace.
+CREATE OR REPLACE FUNCTION public.is_workspace_admin(ws_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.workspace_members
+    WHERE workspace_id = ws_id
+      AND user_id = (SELECT auth.uid())
+      AND role IN ('owner', 'admin')
+      AND accepted_at IS NOT NULL
+  );
+$$;
+
+-- ============================================================
+-- 1. WORKSPACES
+-- ============================================================
+ALTER TABLE "workspaces" ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: owner always sees their workspace; accepted members see it too
+CREATE POLICY "workspaces_select" ON "workspaces"
+  FOR SELECT USING (
+    owner_id = (SELECT auth.uid())
+    OR public.is_workspace_member(id)
+  );
+
+-- INSERT: authenticated user creates workspace as owner
+CREATE POLICY "workspaces_insert" ON "workspaces"
+  FOR INSERT WITH CHECK (
+    owner_id = (SELECT auth.uid())
+  );
+
+-- UPDATE: only workspace owner
+CREATE POLICY "workspaces_update" ON "workspaces"
+  FOR UPDATE USING (
+    owner_id = (SELECT auth.uid())
+  ) WITH CHECK (
+    owner_id = (SELECT auth.uid())
+  );
+
+-- DELETE: only workspace owner
+CREATE POLICY "workspaces_delete" ON "workspaces"
+  FOR DELETE USING (
+    owner_id = (SELECT auth.uid())
+  );
+
+-- ============================================================
+-- 2. WORKSPACE_MEMBERS
+-- ============================================================
+ALTER TABLE "workspace_members" ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: user sees own rows + all members of workspaces they belong to
+CREATE POLICY "workspace_members_select" ON "workspace_members"
+  FOR SELECT USING (
+    user_id = (SELECT auth.uid())
+    OR public.is_workspace_member(workspace_id)
+  );
+
+-- INSERT: workspace owner (from workspaces table) or existing admin can add
+CREATE POLICY "workspace_members_insert" ON "workspace_members"
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.workspaces
+      WHERE id = workspace_id
+        AND owner_id = (SELECT auth.uid())
+    )
+    OR public.is_workspace_admin(workspace_id)
+  );
+
+-- UPDATE: owner or admin of the workspace
+CREATE POLICY "workspace_members_update" ON "workspace_members"
+  FOR UPDATE USING (
+    public.is_workspace_admin(workspace_id)
+  );
+
+-- DELETE: member can leave (remove self) or owner/admin can remove others
+CREATE POLICY "workspace_members_delete" ON "workspace_members"
+  FOR DELETE USING (
+    user_id = (SELECT auth.uid())
+    OR public.is_workspace_admin(workspace_id)
+  );
+
+-- ============================================================
+-- 3. PROJECTS
+-- ============================================================
+ALTER TABLE "projects" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "projects_select" ON "projects"
+  FOR SELECT USING (public.is_workspace_member(workspace_id));
+
+CREATE POLICY "projects_insert" ON "projects"
+  FOR INSERT WITH CHECK (public.is_workspace_member(workspace_id));
+
+CREATE POLICY "projects_update" ON "projects"
+  FOR UPDATE
+  USING  (public.is_workspace_member(workspace_id))
+  WITH CHECK (public.is_workspace_member(workspace_id));
+
+CREATE POLICY "projects_delete" ON "projects"
+  FOR DELETE USING (public.is_workspace_member(workspace_id));
+
+-- ============================================================
+-- 4. BLOCKS
+-- ============================================================
+ALTER TABLE "blocks" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "blocks_select" ON "blocks"
+  FOR SELECT USING (public.is_workspace_member(workspace_id));
+
+CREATE POLICY "blocks_insert" ON "blocks"
+  FOR INSERT WITH CHECK (public.is_workspace_member(workspace_id));
+
+CREATE POLICY "blocks_update" ON "blocks"
+  FOR UPDATE
+  USING  (public.is_workspace_member(workspace_id))
+  WITH CHECK (public.is_workspace_member(workspace_id));
+
+CREATE POLICY "blocks_delete" ON "blocks"
+  FOR DELETE USING (public.is_workspace_member(workspace_id));
+
+-- ============================================================
+-- 5. TAGS
+-- ============================================================
+ALTER TABLE "tags" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "tags_select" ON "tags"
+  FOR SELECT USING (public.is_workspace_member(workspace_id));
+
+CREATE POLICY "tags_insert" ON "tags"
+  FOR INSERT WITH CHECK (public.is_workspace_member(workspace_id));
+
+CREATE POLICY "tags_update" ON "tags"
+  FOR UPDATE
+  USING  (public.is_workspace_member(workspace_id))
+  WITH CHECK (public.is_workspace_member(workspace_id));
+
+CREATE POLICY "tags_delete" ON "tags"
+  FOR DELETE USING (public.is_workspace_member(workspace_id));
+
+-- ============================================================
+-- 6. BLOCK_TAGS
+-- ============================================================
+ALTER TABLE "block_tags" ENABLE ROW LEVEL SECURITY;
+
+-- block_tags has no workspace_id — access derived through blocks table
+CREATE POLICY "block_tags_select" ON "block_tags"
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.blocks
+      WHERE id = block_id
+        AND public.is_workspace_member(workspace_id)
+    )
+  );
+
+CREATE POLICY "block_tags_insert" ON "block_tags"
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.blocks
+      WHERE id = block_id
+        AND public.is_workspace_member(workspace_id)
+    )
+  );
+
+CREATE POLICY "block_tags_delete" ON "block_tags"
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1 FROM public.blocks
+      WHERE id = block_id
+        AND public.is_workspace_member(workspace_id)
+    )
+  );

--- a/supabase/tests/0001_rls_policies_test.sql
+++ b/supabase/tests/0001_rls_policies_test.sql
@@ -1,0 +1,191 @@
+-- ============================================================
+-- RLS policy tests
+--
+-- Verifies that an authenticated user cannot see data belonging
+-- to a workspace they are not a member of.
+--
+-- Run against a local Supabase instance (supabase db test) or
+-- manually via psql. Uses supabase_test helpers where available;
+-- falls back to raw SET ROLE + request.jwt.claims.
+-- ============================================================
+
+BEGIN;
+
+-- --------------------------------------------------------
+-- 0. Setup: create two auth users
+-- --------------------------------------------------------
+INSERT INTO auth.users (id, email, raw_user_meta_data)
+VALUES
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'alice@test.local', '{}'),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'bob@test.local',   '{}');
+
+-- --------------------------------------------------------
+-- 1. Create workspaces — Alice owns ws_alice, Bob owns ws_bob
+-- --------------------------------------------------------
+INSERT INTO workspaces (id, name, slug, type, owner_id)
+VALUES
+  ('11111111-1111-1111-1111-111111111111', 'Alice WS', 'alice-ws', 'personal',
+   'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+  ('22222222-2222-2222-2222-222222222222', 'Bob WS',   'bob-ws',   'personal',
+   'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
+
+-- --------------------------------------------------------
+-- 2. Add each owner as accepted member of their workspace
+-- --------------------------------------------------------
+INSERT INTO workspace_members (workspace_id, user_id, role, accepted_at)
+VALUES
+  ('11111111-1111-1111-1111-111111111111',
+   'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'owner', now()),
+  ('22222222-2222-2222-2222-222222222222',
+   'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'owner', now());
+
+-- --------------------------------------------------------
+-- 3. Create projects, blocks, tags, and block_tags in each WS
+-- --------------------------------------------------------
+INSERT INTO projects (id, workspace_id, name)
+VALUES
+  ('a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1', '11111111-1111-1111-1111-111111111111', 'Alice Project'),
+  ('b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2', '22222222-2222-2222-2222-222222222222', 'Bob Project');
+
+INSERT INTO blocks (id, workspace_id, project_id, type, created_by)
+VALUES
+  ('ca000001-0000-0000-0000-000000000001',
+   '11111111-1111-1111-1111-111111111111',
+   'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+   'task', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+  ('cb000002-0000-0000-0000-000000000002',
+   '22222222-2222-2222-2222-222222222222',
+   'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+   'task', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
+
+INSERT INTO tags (id, workspace_id, name, color)
+VALUES
+  ('da000001-0000-0000-0000-000000000001', '11111111-1111-1111-1111-111111111111', 'Alice Tag', '#ff0000'),
+  ('db000002-0000-0000-0000-000000000002', '22222222-2222-2222-2222-222222222222', 'Bob Tag',   '#0000ff');
+
+INSERT INTO block_tags (block_id, tag_id)
+VALUES
+  ('ca000001-0000-0000-0000-000000000001', 'da000001-0000-0000-0000-000000000001'),
+  ('cb000002-0000-0000-0000-000000000002', 'db000002-0000-0000-0000-000000000002');
+
+-- --------------------------------------------------------
+-- 4. Become Alice (simulate Supabase auth context)
+-- --------------------------------------------------------
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claims = '{"sub":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}';
+
+-- Alice sees her workspace but NOT Bob's
+DO $$
+DECLARE
+  cnt int;
+BEGIN
+  SELECT count(*) INTO cnt FROM workspaces;
+  ASSERT cnt = 1, 'Alice should see exactly 1 workspace, got ' || cnt;
+
+  SELECT count(*) INTO cnt FROM workspaces WHERE slug = 'bob-ws';
+  ASSERT cnt = 0, 'Alice must NOT see Bob workspace';
+END $$;
+
+-- Alice sees her project but NOT Bob's
+DO $$
+DECLARE
+  cnt int;
+BEGIN
+  SELECT count(*) INTO cnt FROM projects;
+  ASSERT cnt = 1, 'Alice should see 1 project, got ' || cnt;
+
+  SELECT count(*) INTO cnt FROM projects WHERE name = 'Bob Project';
+  ASSERT cnt = 0, 'Alice must NOT see Bob project';
+END $$;
+
+-- Alice sees her blocks but NOT Bob's
+DO $$
+DECLARE
+  cnt int;
+BEGIN
+  SELECT count(*) INTO cnt FROM blocks;
+  ASSERT cnt = 1, 'Alice should see 1 block, got ' || cnt;
+
+  SELECT count(*) INTO cnt FROM blocks WHERE id = 'cb000002-0000-0000-0000-000000000002';
+  ASSERT cnt = 0, 'Alice must NOT see Bob block';
+END $$;
+
+-- Alice sees her tags but NOT Bob's
+DO $$
+DECLARE
+  cnt int;
+BEGIN
+  SELECT count(*) INTO cnt FROM tags;
+  ASSERT cnt = 1, 'Alice should see 1 tag, got ' || cnt;
+END $$;
+
+-- Alice sees her block_tags but NOT Bob's
+DO $$
+DECLARE
+  cnt int;
+BEGIN
+  SELECT count(*) INTO cnt FROM block_tags;
+  ASSERT cnt = 1, 'Alice should see 1 block_tag, got ' || cnt;
+END $$;
+
+-- Alice sees only her own workspace_members
+DO $$
+DECLARE
+  cnt int;
+BEGIN
+  SELECT count(*) INTO cnt FROM workspace_members;
+  ASSERT cnt = 1, 'Alice should see 1 membership, got ' || cnt;
+END $$;
+
+-- Alice cannot INSERT a block into Bob's workspace
+DO $$
+BEGIN
+  INSERT INTO blocks (workspace_id, type, created_by)
+  VALUES ('22222222-2222-2222-2222-222222222222', 'task',
+          'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+  RAISE EXCEPTION 'INSERT into foreign workspace should have been denied';
+EXCEPTION
+  WHEN insufficient_privilege THEN
+    -- expected: RLS blocked the insert
+    NULL;
+END $$;
+
+-- --------------------------------------------------------
+-- 5. Become Bob — verify inverse isolation
+-- --------------------------------------------------------
+SET LOCAL request.jwt.claims = '{"sub":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"}';
+
+DO $$
+DECLARE
+  cnt int;
+BEGIN
+  SELECT count(*) INTO cnt FROM workspaces;
+  ASSERT cnt = 1, 'Bob should see exactly 1 workspace, got ' || cnt;
+
+  SELECT count(*) INTO cnt FROM blocks;
+  ASSERT cnt = 1, 'Bob should see 1 block, got ' || cnt;
+
+  SELECT count(*) INTO cnt FROM projects;
+  ASSERT cnt = 1, 'Bob should see 1 project, got ' || cnt;
+
+  SELECT count(*) INTO cnt FROM tags;
+  ASSERT cnt = 1, 'Bob should see 1 tag, got ' || cnt;
+
+  SELECT count(*) INTO cnt FROM block_tags;
+  ASSERT cnt = 1, 'Bob should see 1 block_tag, got ' || cnt;
+END $$;
+
+-- Bob cannot delete Alice's workspace
+DO $$
+DECLARE
+  cnt int;
+BEGIN
+  DELETE FROM workspaces WHERE id = '11111111-1111-1111-1111-111111111111';
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  ASSERT cnt = 0, 'Bob must NOT be able to delete Alice workspace';
+END $$;
+
+-- --------------------------------------------------------
+-- 6. Cleanup — rollback so no test data persists
+-- --------------------------------------------------------
+ROLLBACK;


### PR DESCRIPTION
Enable Row Level Security on all 6 tables (workspaces, workspace_members, projects, blocks, tags, block_tags) with CRUD policies enforcing workspace isolation through workspace_members — never user_id directly on content tables.

Includes SECURITY DEFINER helper functions (is_workspace_member, is_workspace_admin) to avoid self-referencing policy recursion and keep policies DRY.

Adds SQL test file verifying cross-workspace data isolation.

https://claude.ai/code/session_01XaS7DxyzLs8y8mSnqnvXMN