### PR TITLE
feat: auto-create workspaces (Prywatna + Służbowa) after registration

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
 import { redirect } from "next/navigation";
 import { createServerClient } from "@/lib/supabase/server";
+import { ensureWorkspacesExist } from "@/lib/db/ensure-workspaces";
 
 /**
  * Strona główna — przekierowuje na podstawie stanu autentykacji.
  *
  * - Zalogowany → pierwszy workspace (po slug)
+ *   - Jeśli brak workspace'ów — automatycznie tworzy dwa domyślne
  * - Niezalogowany → /login
  */
 export default async function HomePage() {
@@ -38,6 +40,7 @@ export default async function HomePage() {
     }
   }
 
-  // Brak workspace — redirect do loginu (workspace powinien być tworzony przy rejestracji)
-  redirect("/login");
+  // Brak workspace — auto-tworzenie domyślnych workspace'ów
+  const slug = await ensureWorkspacesExist(user.id, user.email ?? user.id);
+  redirect(`/${slug}`);
 }

--- a/src/lib/db/ensure-workspaces.ts
+++ b/src/lib/db/ensure-workspaces.ts
@@ -1,0 +1,93 @@
+import { db } from "@/lib/db";
+import { workspaces, workspaceMembers } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+/**
+ * Tworzy domyślne workspace'y (Prywatna + Służbowa) dla nowego użytkownika.
+ *
+ * Wywoływane przy pierwszym wejściu zalogowanego użytkownika,
+ * gdy nie ma jeszcze żadnego membership w workspace_members.
+ *
+ * Zwraca slug pierwszego workspace'a (personal) do redirect.
+ */
+export async function ensureWorkspacesExist(
+  userId: string,
+  email: string
+): Promise<string> {
+  // Sprawdź, czy użytkownik ma już jakieś workspace'y
+  const existing = await db
+    .select({ workspaceId: workspaceMembers.workspaceId })
+    .from(workspaceMembers)
+    .where(eq(workspaceMembers.userId, userId))
+    .limit(1);
+
+  if (existing.length > 0) {
+    // Już ma workspace — pobierz slug pierwszego
+    const ws = await db
+      .select({ slug: workspaces.slug })
+      .from(workspaces)
+      .where(eq(workspaces.id, existing[0].workspaceId))
+      .limit(1);
+
+    return ws[0].slug;
+  }
+
+  // Generuj bazowy slug z email (przed @, bez znaków specjalnych)
+  // Dodajemy krótki suffix z userId aby uniknąć kolizji slugów
+  const emailPrefix = email
+    .split("@")[0]
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  const suffix = userId.slice(0, 6);
+  const baseSlug = `${emailPrefix}-${suffix}`;
+
+  const now = new Date();
+
+  // Twórz oba workspace'y w transakcji
+  const personalSlug = `${baseSlug}-personal`;
+  const workSlug = `${baseSlug}-work`;
+
+  const [personalWs] = await db.transaction(async (tx) => {
+    const [personal] = await tx
+      .insert(workspaces)
+      .values({
+        name: "Prywatna",
+        slug: personalSlug,
+        type: "personal",
+        ownerId: userId,
+      })
+      .returning();
+
+    const [work] = await tx
+      .insert(workspaces)
+      .values({
+        name: "Służbowa",
+        slug: workSlug,
+        type: "work",
+        ownerId: userId,
+      })
+      .returning();
+
+    // Dodaj użytkownika jako ownera do obu workspace'ów
+    await tx.insert(workspaceMembers).values([
+      {
+        workspaceId: personal.id,
+        userId,
+        role: "owner",
+        acceptedAt: now,
+      },
+      {
+        workspaceId: work.id,
+        userId,
+        role: "owner",
+        acceptedAt: now,
+      },
+    ]);
+
+    return [personal, work];
+  });
+
+  return personalWs.slug;
+}


### PR DESCRIPTION
When a logged-in user has no workspaces, the root page now auto-creates
two default workspaces via Drizzle ORM transaction and redirects to the
personal workspace. Each workspace gets a workspace_members entry with
role=owner and accepted_at set immediately.

https://claude.ai/code/session_01SCbE858M1Ujj8qRdjGgjVS