### PR TITLE
feat: layout główny dashboardu — Sidebar + Navbar (#7)

### DIFF
--- a/src/app/(dashboard)/[workspaceSlug]/layout.tsx
+++ b/src/app/(dashboard)/[workspaceSlug]/layout.tsx
@@ -1,0 +1,97 @@
+import { Suspense } from "react";
+import { redirect } from "next/navigation";
+import { createServerClient } from "@/lib/supabase/server";
+import { Sidebar, SidebarSkeleton } from "@/components/layout/Sidebar";
+import { Navbar } from "@/components/layout/Navbar";
+
+interface WorkspaceLayoutProps {
+  children: React.ReactNode;
+  params: Promise<{ workspaceSlug: string }>;
+}
+
+interface DashboardShellProps {
+  children: React.ReactNode;
+  workspaceSlug: string;
+}
+
+async function DashboardShell({ children, workspaceSlug }: DashboardShellProps) {
+  const supabase = await createServerClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { data: memberships, error: membershipsError } = await supabase
+    .from("workspace_members")
+    .select("workspace_id")
+    .eq("user_id", user.id);
+
+  if (membershipsError || !memberships?.length) {
+    redirect("/");
+  }
+
+  const workspaceIds = memberships.map((membership) => membership.workspace_id);
+
+  const { data: workspaces, error: workspacesError } = await supabase
+    .from("workspaces")
+    .select("id, name, slug, type")
+    .in("id", workspaceIds)
+    .order("created_at", { ascending: true });
+
+  if (workspacesError || !workspaces?.length) {
+    redirect("/");
+  }
+
+  const currentWorkspace = workspaces.find((workspace) => workspace.slug === workspaceSlug);
+
+  if (!currentWorkspace) {
+    redirect(`/${workspaces[0].slug}`);
+  }
+
+  const { data: projects } = await supabase
+    .from("projects")
+    .select("id, name")
+    .eq("workspace_id", currentWorkspace.id)
+    .order("created_at", { ascending: true });
+
+  return (
+    <>
+      <Sidebar
+        currentWorkspaceSlug={workspaceSlug}
+        workspaces={workspaces}
+        projects={projects ?? []}
+      />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <Navbar workspaceName={currentWorkspace.name} userEmail={user.email ?? user.id} />
+        <main className="flex-1 overflow-y-auto bg-bg-base">{children}</main>
+      </div>
+    </>
+  );
+}
+
+function DashboardLayoutFallback() {
+  return (
+    <>
+      <SidebarSkeleton />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="h-12 border-b border-border-subtle bg-bg-base" />
+      </div>
+    </>
+  );
+}
+
+export default async function WorkspaceLayout({ children, params }: WorkspaceLayoutProps) {
+  const { workspaceSlug } = await params;
+
+  return (
+    <div className="flex min-h-screen bg-bg-base text-content-primary">
+      <Suspense fallback={<DashboardLayoutFallback />}>
+        <DashboardShell workspaceSlug={workspaceSlug}>{children}</DashboardShell>
+      </Suspense>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/[workspaceSlug]/page.tsx
+++ b/src/app/(dashboard)/[workspaceSlug]/page.tsx
@@ -21,7 +21,6 @@ export default async function WorkspacePage({ params }: WorkspacePageProps) {
     redirect("/login");
   }
 
-  // Sprawdź, czy workspace istnieje i użytkownik ma do niego dostęp
   const { data: workspace } = await supabase
     .from("workspaces")
     .select("id, name, slug")
@@ -32,7 +31,6 @@ export default async function WorkspacePage({ params }: WorkspacePageProps) {
     redirect("/");
   }
 
-  // Sprawdź membership
   const { data: membership } = await supabase
     .from("workspace_members")
     .select("role")
@@ -44,14 +42,24 @@ export default async function WorkspacePage({ params }: WorkspacePageProps) {
     redirect("/");
   }
 
+  const { data: firstProject } = await supabase
+    .from("projects")
+    .select("id")
+    .eq("workspace_id", workspace.id)
+    .order("created_at", { ascending: true })
+    .limit(1)
+    .single();
+
+  if (firstProject) {
+    redirect(`/${workspaceSlug}/board/${firstProject.id}`);
+  }
+
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-bg-base px-4">
-      <div className="max-w-md text-center">
-        <h1 className="text-2xl font-semibold text-content-primary">
-          {workspace.name}
-        </h1>
+    <div className="px-8 py-6">
+      <div className="max-w-[720px]">
+        <h1 className="text-2xl font-semibold text-content-primary">{workspace.name}</h1>
         <p className="mt-2 text-content-muted">
-          Workspace jest gotowy. Sidebar, projekty i widok Kanban — wkrótce.
+          Brak projektów. Utwórz pierwszy projekt, aby rozpocząć pracę z tablicą.
         </p>
       </div>
     </div>

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,0 +1,5 @@
+export default function DashboardGroupLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useMemo } from "react";
+import { usePathname } from "next/navigation";
+
+interface NavbarProps {
+  workspaceName: string;
+  userEmail: string;
+}
+
+function toCrumb(segment: string) {
+  return segment
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function Navbar({ workspaceName, userEmail }: NavbarProps) {
+  const pathname = usePathname();
+
+  const breadcrumbs = useMemo(() => {
+    const segments = pathname.split("/").filter(Boolean);
+
+    if (!segments.length) {
+      return [workspaceName];
+    }
+
+    const [, ...rest] = segments;
+    return [workspaceName, ...rest.map(toCrumb)];
+  }, [pathname, workspaceName]);
+
+  const avatarFallback = (userEmail[0] ?? "U").toUpperCase();
+
+  return (
+    <header className="flex h-12 items-center justify-between border-b border-border-subtle bg-bg-base px-4">
+      <nav className="flex min-w-0 items-center gap-2 text-sm text-content-secondary">
+        {breadcrumbs.map((crumb, index) => (
+          <div key={`${crumb}-${index}`} className="flex min-w-0 items-center gap-2">
+            {index > 0 && <span className="text-content-muted">/</span>}
+            <span
+              className={index === breadcrumbs.length - 1 ? "truncate text-content-primary" : "truncate"}
+            >
+              {crumb}
+            </span>
+          </div>
+        ))}
+      </nav>
+
+      <div className="flex h-8 w-8 items-center justify-center rounded-full border border-border-default bg-bg-surface text-sm font-medium text-content-primary">
+        {avatarFallback}
+      </div>
+    </header>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import type { ComponentType } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  ChevronLeft,
+  ChevronRight,
+  FolderKanban,
+  NotebookPen,
+  Settings,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useSidebarStore } from "@/lib/stores/sidebar-store";
+
+interface WorkspaceItem {
+  id: string;
+  name: string;
+  slug: string;
+  type: "personal" | "work";
+}
+
+interface ProjectItem {
+  id: string;
+  name: string;
+}
+
+interface SidebarProps {
+  currentWorkspaceSlug: string;
+  workspaces: WorkspaceItem[];
+  projects: ProjectItem[];
+}
+
+interface SidebarLinkProps {
+  href: string;
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  isActive: boolean;
+  collapsed: boolean;
+}
+
+function workspaceDotColor(type: WorkspaceItem["type"]) {
+  return type === "personal" ? "bg-violet-500" : "bg-sky-500";
+}
+
+function SidebarLink({ href, label, icon: Icon, isActive, collapsed }: SidebarLinkProps) {
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "group flex h-9 items-center rounded-md border-l-2 border-transparent px-3 text-sm text-content-secondary transition-all duration-200 hover:bg-bg-elevated hover:pl-3.5 hover:text-content-primary",
+        isActive && "border-l-sky-500 bg-bg-elevated text-content-primary"
+      )}
+      title={collapsed ? label : undefined}
+    >
+      <Icon className="h-4 w-4 shrink-0" />
+      {!collapsed && <span className="ml-2 truncate">{label}</span>}
+    </Link>
+  );
+}
+
+export function SidebarSkeleton() {
+  return (
+    <aside className="w-60 shrink-0 border-r border-border-subtle bg-bg-subtle p-3">
+      <div className="h-8 w-full animate-pulse rounded-md bg-bg-elevated" />
+      <div className="mt-6 space-y-2">
+        <div className="h-9 animate-pulse rounded-md bg-bg-elevated" />
+        <div className="h-9 animate-pulse rounded-md bg-bg-elevated" />
+        <div className="h-9 animate-pulse rounded-md bg-bg-elevated" />
+      </div>
+      <div className="mt-6 space-y-2">
+        <div className="h-3 w-20 animate-pulse rounded bg-bg-elevated" />
+        <div className="h-8 animate-pulse rounded-md bg-bg-elevated" />
+        <div className="h-8 animate-pulse rounded-md bg-bg-elevated" />
+      </div>
+    </aside>
+  );
+}
+
+export function Sidebar({ currentWorkspaceSlug, workspaces, projects }: SidebarProps) {
+  const pathname = usePathname();
+  const { isCollapsed, toggle } = useSidebarStore();
+
+  return (
+    <aside
+      className={cn(
+        "flex h-screen shrink-0 flex-col border-r border-border-subtle bg-bg-subtle p-3 transition-all duration-200",
+        isCollapsed ? "w-14" : "w-60"
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        {!isCollapsed && (
+          <div className="min-w-0 flex-1">
+            <p className="text-xs uppercase tracking-wider text-content-muted">Workspace</p>
+            <p className="truncate text-sm font-medium text-content-primary">
+              {workspaces.find((workspace) => workspace.slug === currentWorkspaceSlug)?.name ?? "Workspace"}
+            </p>
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={toggle}
+          className="flex h-8 w-8 items-center justify-center rounded-md border border-border-subtle bg-bg-surface text-content-muted transition-colors duration-150 hover:bg-bg-elevated hover:text-content-primary"
+          aria-label={isCollapsed ? "Rozwiń sidebar" : "Zwiń sidebar"}
+        >
+          {isCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
+        </button>
+      </div>
+
+      {!isCollapsed && (
+        <div className="mt-4 space-y-1 rounded-md border border-border-subtle bg-bg-surface p-2">
+          {workspaces.map((workspace) => {
+            const isWorkspaceActive = workspace.slug === currentWorkspaceSlug;
+
+            return (
+              <Link
+                key={workspace.id}
+                href={`/${workspace.slug}`}
+                className={cn(
+                  "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-content-secondary transition-colors duration-150 hover:bg-bg-elevated hover:text-content-primary",
+                  isWorkspaceActive && "bg-bg-elevated text-content-primary"
+                )}
+              >
+                <span className={cn("h-2 w-2 rounded-full", workspaceDotColor(workspace.type))} />
+                <span className="truncate">{workspace.name}</span>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+
+      <nav className="mt-6 space-y-1">
+        <SidebarLink
+          href={`/${currentWorkspaceSlug}/notes`}
+          label="Notatki"
+          icon={NotebookPen}
+          isActive={pathname.includes("/notes")}
+          collapsed={isCollapsed}
+        />
+        <SidebarLink
+          href={`/${currentWorkspaceSlug}/settings/members`}
+          label="Ustawienia"
+          icon={Settings}
+          isActive={pathname.includes("/settings")}
+          collapsed={isCollapsed}
+        />
+      </nav>
+
+      <div className="mt-6 flex-1 overflow-y-auto">
+        {!isCollapsed && (
+          <p className="px-3 pb-1 text-xs uppercase tracking-wider text-content-muted">Projekty</p>
+        )}
+        <div className="space-y-1">
+          {projects.map((project) => {
+            const projectHref = `/${currentWorkspaceSlug}/board/${project.id}`;
+            return (
+              <SidebarLink
+                key={project.id}
+                href={projectHref}
+                label={project.name}
+                icon={FolderKanban}
+                isActive={pathname.startsWith(projectHref)}
+                collapsed={isCollapsed}
+              />
+            );
+          })}
+          {!projects.length && !isCollapsed && (
+            <p className="px-3 pt-2 text-xs text-content-muted">Brak projektów w tym workspace.</p>
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/lib/stores/sidebar-store.ts
+++ b/src/lib/stores/sidebar-store.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface SidebarState {
+  isCollapsed: boolean;
+  toggle: () => void;
+  setCollapsed: (collapsed: boolean) => void;
+}
+
+export const useSidebarStore = create<SidebarState>((set) => ({
+  isCollapsed: false,
+  toggle: () => set((state) => ({ isCollapsed: !state.isCollapsed })),
+  setCollapsed: (collapsed) => set({ isCollapsed: collapsed }),
+}));


### PR DESCRIPTION
### Motivation
- Wprowadzić bazowy szkielet UI widoczny po zalogowaniu: sidebar z nawigacją i workspace switcher oraz górny navbar z breadcrumb i avatarem, aby udostępnić wspólny shell dla widoków dashboardu.

### Description
- Dodano layout grupowy `/(dashboard)` passthrough oraz workspace layout `src/app/(dashboard)/[workspaceSlug]/layout.tsx` ładujący autoryzowane dane użytkownika, workspaces i projekty oraz renderujący `Sidebar + Navbar + main` wraz z fallbackem `Suspense`.
- Dodano komponenty layoutu `src/components/layout/Sidebar.tsx` (workspace switcher, projekty, notatki, ustawienia, aktywny link, skeleton, collapsible) i `src/components/layout/Navbar.tsx` (breadcrumb z pathname i avatar fallback).
- Zaimplementowano store Zustand `src/lib/stores/sidebar-store.ts` zarządzający stanem zwinięcia sidebara i użyty w `Sidebar` dla animowanej zmiany szerokości.
- Zaktualizowano stronę workspace `src/app/(dashboard)/[workspaceSlug]/page.tsx` aby przekierowywać do pierwszego projektu (`/board/:projectId`) lub wyświetlić placeholder gdy brak projektów.

### Testing
- Uruchomiono `npm run build` i build przeszedł pomyślnie (`✅`).
- Uruchomiono `npm run lint` i zakończyło się błędem środowiskowym z brakiem modułu `eslint-config-next/core-web-vitals` (`⚠️`).
- W trybie deweloperskim uruchomiono aplikację (`next dev`) i wykonano automatyczny Playwright screenshot pod `/demo-workspace`; screenshot został wygenerowany, ale trasa dashboardowa w tym środowisku ujawniła zachowanie auth/SSR (przekierowanie / auth-gate) co ograniczyło pełne renderowanie UI (`⚠️`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f581500948330bae0e0537be077ba)