### PR TITLE
feat: widok Kanban z kolumnami statycznymi i kartami zadań

### DIFF
--- a/src/components/board/KanbanBoard.tsx
+++ b/src/components/board/KanbanBoard.tsx
@@ -1,0 +1,25 @@
+import { KanbanColumn, type KanbanTaskCard } from "@/components/board/KanbanColumn";
+import type { TaskStatus } from "@/lib/db/types";
+
+interface KanbanBoardProps {
+  workspaceSlug: string;
+  columns: Record<TaskStatus, KanbanTaskCard[]>;
+}
+
+const COLUMN_TITLES: Record<TaskStatus, string> = {
+  todo: "Todo",
+  in_progress: "In Progress",
+  done: "Done",
+};
+
+const COLUMN_ORDER: TaskStatus[] = ["todo", "in_progress", "done"];
+
+export function KanbanBoard({ workspaceSlug, columns }: KanbanBoardProps) {
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+      {COLUMN_ORDER.map((status) => (
+        <KanbanColumn key={status} title={COLUMN_TITLES[status]} workspaceSlug={workspaceSlug} cards={columns[status]} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/board/KanbanCard.tsx
+++ b/src/components/board/KanbanCard.tsx
@@ -1,0 +1,76 @@
+import Link from "next/link";
+import { CalendarDays, Flag, User } from "lucide-react";
+
+interface KanbanCardProps {
+  blockId: string;
+  workspaceSlug: string;
+  title: string;
+  priority?: "low" | "medium" | "high" | "urgent";
+  dueDate?: string;
+  assignee?: string;
+}
+
+const PRIORITY_LABELS: Record<NonNullable<KanbanCardProps["priority"]>, string> = {
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  urgent: "Urgent",
+};
+
+function formatDueDate(dueDate?: string): string {
+  if (!dueDate) {
+    return "Brak terminu";
+  }
+
+  const date = new Date(dueDate);
+
+  if (Number.isNaN(date.getTime())) {
+    return dueDate;
+  }
+
+  return new Intl.DateTimeFormat("pl-PL", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  }).format(date);
+}
+
+function formatAssignee(assignee?: string): string {
+  if (!assignee) {
+    return "Nieprzypisane";
+  }
+
+  if (assignee.length <= 10) {
+    return assignee;
+  }
+
+  return `${assignee.slice(0, 8)}…`;
+}
+
+export function KanbanCard({ blockId, workspaceSlug, title, priority, dueDate, assignee }: KanbanCardProps) {
+  return (
+    <Link
+      href={`/${workspaceSlug}/block/${blockId}`}
+      className="block rounded-lg border border-border-subtle bg-bg-surface p-3 transition-all duration-150 hover:-translate-y-px hover:border-border-default hover:bg-bg-elevated hover:shadow-md"
+    >
+      <p className="line-clamp-2 text-sm font-medium text-content-primary">{title}</p>
+
+      <div className="mt-3 space-y-1.5 text-xs text-content-muted">
+        <div className="flex items-center gap-1.5">
+          <Flag className="h-3.5 w-3.5" aria-hidden="true" />
+          <span>{priority ? PRIORITY_LABELS[priority] : "Brak priorytetu"}</span>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+          <span>{formatDueDate(dueDate)}</span>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <User className="h-3.5 w-3.5" aria-hidden="true" />
+          <span>{formatAssignee(assignee)}</span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/board/KanbanColumn.tsx
+++ b/src/components/board/KanbanColumn.tsx
@@ -1,0 +1,54 @@
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { KanbanCard } from "@/components/board/KanbanCard";
+
+interface KanbanTaskCard {
+  id: string;
+  title: string;
+  priority?: "low" | "medium" | "high" | "urgent";
+  dueDate?: string;
+  assignee?: string;
+}
+
+interface KanbanColumnProps {
+  title: string;
+  workspaceSlug: string;
+  cards: KanbanTaskCard[];
+}
+
+export function KanbanColumn({ title, workspaceSlug, cards }: KanbanColumnProps) {
+  return (
+    <section className="flex min-h-[420px] flex-col rounded-xl border border-border-subtle bg-bg-base p-3">
+      <div className="mb-3 flex items-center justify-between px-1">
+        <h2 className="text-sm font-semibold text-content-secondary">{title}</h2>
+        <span className="rounded-full bg-bg-elevated px-2 py-0.5 text-xs text-content-muted">{cards.length}</span>
+      </div>
+
+      <div className="flex flex-1 flex-col gap-2">
+        {cards.length === 0 ? (
+          <div className="flex flex-1 flex-col items-center justify-center rounded-lg border border-dashed border-border-subtle bg-bg-surface/60 px-4 text-center">
+            <p className="text-sm text-content-muted">Brak zadań w kolumnie.</p>
+            <Button type="button" variant="secondary" size="sm" className="mt-3 gap-1.5" disabled>
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Dodaj zadanie
+            </Button>
+          </div>
+        ) : (
+          cards.map((card) => (
+            <KanbanCard
+              key={card.id}
+              blockId={card.id}
+              workspaceSlug={workspaceSlug}
+              title={card.title}
+              priority={card.priority}
+              dueDate={card.dueDate}
+              assignee={card.assignee}
+            />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+export type { KanbanTaskCard };


### PR DESCRIPTION
### Motivation
- Dostarczyć widok Kanban pod ścieżką `/[workspaceSlug]/board/[projectId]` wyświetlający bloki `type='task'` pogrupowane po `status` w trzy statyczne kolumny `todo | in_progress | done`.
- Udostępnić podstawowe komponenty UI (kontener kolumn, kolumna, karta) pokazujące kluczowe właściwości zadania: tytuł, priorytet, `due_date` i `assignee`.
- Przygotować fundament pod kolejne kroki (DnD i optimistic updates) zgodnie z architekturą projektu.

### Description
- Dodano komponenty `KanbanBoard`, `KanbanColumn` i `KanbanCard` w `src/components/board/` ze strukturą kolumn, nagłówkami, licznikiem i pustym stanem z CTA (`Dodaj zadanie`).
- Zaktualizowano stronę boarda `src/app/(dashboard)/[workspaceSlug]/board/[projectId]/page.tsx` aby po stronie serwera pobierać `blocks` typu `task` przez `createServerClient`, normalizować status i grupować zadania do `columns: Record<TaskStatus, KanbanTaskCard[]>`.
- Karta zadania renderuje tytuł (fallback `Bez tytułu`), priorytet (czytelne etykiety), sformatowaną datę (`pl-PL`) oraz skróconego `assignee`, i linkuje do widoku bloku (`/[workspaceSlug]/block/[blockId]`).
- Wszystkie pliki są w TypeScript, używają istniejących typów (`TaskStatus`, `KanbanTaskCard`) i trzymają się konwencji projektu (RSC gdzie to właściwe, pełne pliki).

### Testing
- Uruchomiono `npm run build` i budowanie zakończyło się pomyślnie.
- Uruchomiono `npm run lint`, które w tym środowisku zwróciło błąd z powodu brakującego modułu `eslint-config-next/core-web-vitals` (środowiskowy problem z konfiguracją ESLint).
- Wystartowano serwer deweloperski i wykonano Playwright: zrobiono screenshot `/login` pomyślnie, natomiast próba załadowania testowego boarda zwróciła `net::ERR_EMPTY_RESPONSE` (problem z dostępnością endpointu podczas testu).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe95d3314833091ccdf3669d6c7b0)