### PR TITLE
feat: implement task block CRUD on Kanban board (#11)

### DIFF
--- a/src/app/(dashboard)/[workspaceSlug]/board/[projectId]/page.tsx
+++ b/src/app/(dashboard)/[workspaceSlug]/board/[projectId]/page.tsx
@@ -93,6 +93,7 @@ export default async function ProjectBoardPage({ params }: ProjectBoardPageProps
     columns[status].push({
       id: task.id,
       title: task.properties?.title?.trim() || "Bez tytułu",
+      status,
       priority: task.properties?.priority,
       dueDate: task.properties?.due_date,
       assignee: task.properties?.assigned_to,
@@ -109,7 +110,7 @@ export default async function ProjectBoardPage({ params }: ProjectBoardPageProps
         </div>
       </div>
 
-      <KanbanBoard workspaceSlug={workspaceSlug} columns={columns} />
+      <KanbanBoard workspaceSlug={workspaceSlug} workspaceId={workspace.id} projectId={project.id} columns={columns} />
     </div>
   );
 }

--- a/src/app/api/blocks/[id]/route.ts
+++ b/src/app/api/blocks/[id]/route.ts
@@ -1,0 +1,137 @@
+import { NextResponse } from "next/server";
+import { TASK_STATUSES, type TaskStatus } from "@/lib/db/types";
+import { createServerClient } from "@/lib/supabase/server";
+
+interface UpdateBlockPayload {
+  title?: string;
+  status?: TaskStatus;
+}
+
+interface TaskProperties {
+  title?: string;
+  status?: TaskStatus;
+  due_date?: string;
+  priority?: "low" | "medium" | "high" | "urgent";
+  assigned_to?: string;
+}
+
+function isTaskStatus(value?: string): value is TaskStatus {
+  if (!value) {
+    return false;
+  }
+
+  return TASK_STATUSES.includes(value as TaskStatus);
+}
+
+async function ensureTaskAccess(taskId: string, userId: string) {
+  const supabase = await createServerClient();
+
+  const { data: block, error: blockError } = await supabase
+    .from("blocks")
+    .select("id, workspace_id, type, properties")
+    .eq("id", taskId)
+    .single();
+
+  if (blockError || !block) {
+    return { data: null, error: "Task not found", status: 404 as const, supabase };
+  }
+
+  if (block.type !== "task") {
+    return { data: null, error: "Block is not a task", status: 400 as const, supabase };
+  }
+
+  const { data: membership, error: membershipError } = await supabase
+    .from("workspace_members")
+    .select("workspace_id")
+    .eq("workspace_id", block.workspace_id)
+    .eq("user_id", userId)
+    .single();
+
+  if (membershipError || !membership) {
+    return { data: null, error: "Forbidden", status: 403 as const, supabase };
+  }
+
+  return { data: block, error: null, status: 200 as const, supabase };
+}
+
+export async function PATCH(request: Request, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const supabase = await createServerClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const access = await ensureTaskAccess(id, user.id);
+
+  if (access.error || !access.data) {
+    return NextResponse.json({ data: null, error: access.error }, { status: access.status });
+  }
+
+  const body = (await request.json()) as UpdateBlockPayload;
+  const currentProperties = (access.data.properties ?? {}) as TaskProperties;
+
+  if (typeof body.title === "string" && !body.title.trim()) {
+    return NextResponse.json({ data: null, error: "Tytuł jest wymagany." }, { status: 400 });
+  }
+
+  if (typeof body.status === "string" && !isTaskStatus(body.status)) {
+    return NextResponse.json({ data: null, error: "Nieprawidłowy status zadania." }, { status: 400 });
+  }
+
+  if (typeof body.title !== "string" && typeof body.status !== "string") {
+    return NextResponse.json({ data: null, error: "Brak danych do aktualizacji." }, { status: 400 });
+  }
+
+  const nextProperties: TaskProperties = {
+    ...currentProperties,
+    ...(typeof body.title === "string" ? { title: body.title.trim() } : {}),
+    ...(typeof body.status === "string" ? { status: body.status } : {}),
+  };
+
+  const { data, error } = await access.supabase
+    .from("blocks")
+    .update({ properties: nextProperties, updated_at: new Date().toISOString() })
+    .eq("id", id)
+    .select("id, properties")
+    .single();
+
+  if (error || !data) {
+    return NextResponse.json({ data: null, error: error?.message ?? "Nie udało się zaktualizować zadania." }, { status: 500 });
+  }
+
+  return NextResponse.json({ data, error: null });
+}
+
+export async function DELETE(_request: Request, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const supabase = await createServerClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const access = await ensureTaskAccess(id, user.id);
+
+  if (access.error || !access.data) {
+    return NextResponse.json({ data: null, error: access.error }, { status: access.status });
+  }
+
+  const { error } = await access.supabase.from("blocks").delete().eq("id", id);
+
+  if (error) {
+    return NextResponse.json({ data: null, error: "Nie udało się usunąć zadania." }, { status: 500 });
+  }
+
+  return NextResponse.json({ data: { id }, error: null });
+}

--- a/src/app/api/blocks/route.ts
+++ b/src/app/api/blocks/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+import { TASK_STATUSES, type TaskStatus } from "@/lib/db/types";
+import { createServerClient } from "@/lib/supabase/server";
+
+interface CreateBlockPayload {
+  workspaceId?: string;
+  projectId?: string;
+  type?: string;
+  title?: string;
+  status?: TaskStatus;
+}
+
+function isTaskStatus(value?: string): value is TaskStatus {
+  if (!value) {
+    return false;
+  }
+
+  return TASK_STATUSES.includes(value as TaskStatus);
+}
+
+export async function POST(request: Request) {
+  const supabase = await createServerClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = (await request.json()) as CreateBlockPayload;
+
+  if (body.type !== "task") {
+    return NextResponse.json({ data: null, error: "Dozwolone jest tworzenie wyłącznie bloków task." }, { status: 400 });
+  }
+
+  if (!body.workspaceId || !body.projectId) {
+    return NextResponse.json({ data: null, error: "workspaceId i projectId są wymagane." }, { status: 400 });
+  }
+
+  if (!body.title?.trim()) {
+    return NextResponse.json({ data: null, error: "Tytuł jest wymagany." }, { status: 400 });
+  }
+
+  if (!isTaskStatus(body.status)) {
+    return NextResponse.json({ data: null, error: "Nieprawidłowy status zadania." }, { status: 400 });
+  }
+
+  const { data: membership, error: membershipError } = await supabase
+    .from("workspace_members")
+    .select("workspace_id")
+    .eq("workspace_id", body.workspaceId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (membershipError || !membership) {
+    return NextResponse.json({ data: null, error: "Brak dostępu do workspace." }, { status: 403 });
+  }
+
+  const { data: lastTask } = await supabase
+    .from("blocks")
+    .select("position")
+    .eq("workspace_id", body.workspaceId)
+    .eq("project_id", body.projectId)
+    .eq("type", "task")
+    .order("position", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const nextPosition = (lastTask?.position ?? 0) + 1;
+
+  const { data, error } = await supabase
+    .from("blocks")
+    .insert({
+      workspace_id: body.workspaceId,
+      project_id: body.projectId,
+      type: "task",
+      created_by: user.id,
+      position: nextPosition,
+      properties: {
+        title: body.title.trim(),
+        status: body.status,
+      },
+    })
+    .select("id, properties")
+    .single();
+
+  if (error || !data) {
+    return NextResponse.json({ data: null, error: error?.message ?? "Nie udało się utworzyć zadania." }, { status: 500 });
+  }
+
+  return NextResponse.json({ data, error: null }, { status: 201 });
+}

--- a/src/components/board/KanbanBoard.tsx
+++ b/src/components/board/KanbanBoard.tsx
@@ -1,9 +1,30 @@
+"use client";
+
+import { useState } from "react";
 import { KanbanColumn, type KanbanTaskCard } from "@/components/board/KanbanColumn";
-import type { TaskStatus } from "@/lib/db/types";
+import { TASK_STATUSES, type TaskStatus } from "@/lib/db/types";
 
 interface KanbanBoardProps {
   workspaceSlug: string;
+  workspaceId: string;
+  projectId: string;
   columns: Record<TaskStatus, KanbanTaskCard[]>;
+}
+
+interface ApiResponse<T> {
+  data: T | null;
+  error: string | null;
+}
+
+interface BlockApiData {
+  id: string;
+  properties: {
+    title?: string;
+    status?: TaskStatus;
+    due_date?: string;
+    priority?: "low" | "medium" | "high" | "urgent";
+    assigned_to?: string;
+  };
 }
 
 const COLUMN_TITLES: Record<TaskStatus, string> = {
@@ -12,13 +33,131 @@ const COLUMN_TITLES: Record<TaskStatus, string> = {
   done: "Done",
 };
 
-const COLUMN_ORDER: TaskStatus[] = ["todo", "in_progress", "done"];
+function isTaskStatus(value: string): value is TaskStatus {
+  return TASK_STATUSES.includes(value as TaskStatus);
+}
 
-export function KanbanBoard({ workspaceSlug, columns }: KanbanBoardProps) {
+function upsertCard(columns: Record<TaskStatus, KanbanTaskCard[]>, nextCard: KanbanTaskCard): Record<TaskStatus, KanbanTaskCard[]> {
+  const nextColumns: Record<TaskStatus, KanbanTaskCard[]> = {
+    todo: columns.todo.filter((card) => card.id !== nextCard.id),
+    in_progress: columns.in_progress.filter((card) => card.id !== nextCard.id),
+    done: columns.done.filter((card) => card.id !== nextCard.id),
+  };
+
+  nextColumns[nextCard.status] = [nextCard, ...nextColumns[nextCard.status]];
+
+  return nextColumns;
+}
+
+export function KanbanBoard({ workspaceSlug, workspaceId, projectId, columns }: KanbanBoardProps) {
+  const [boardColumns, setBoardColumns] = useState(columns);
+  const [creatingByStatus, setCreatingByStatus] = useState<Record<TaskStatus, boolean>>({
+    todo: false,
+    in_progress: false,
+    done: false,
+  });
+
+  const handleCreateTask = async (status: TaskStatus, title: string) => {
+    const optimisticId = `optimistic-${Date.now()}`;
+
+    setCreatingByStatus((previous) => ({ ...previous, [status]: true }));
+    setBoardColumns((previous) => upsertCard(previous, { id: optimisticId, title, status, isOptimistic: true }));
+
+    const response = await fetch("/api/blocks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ workspaceId, projectId, type: "task", title, status }),
+    });
+
+    const result = (await response.json()) as ApiResponse<BlockApiData>;
+
+    if (!response.ok || !result.data) {
+      setBoardColumns((previous) => ({
+        todo: previous.todo.filter((card) => card.id !== optimisticId),
+        in_progress: previous.in_progress.filter((card) => card.id !== optimisticId),
+        done: previous.done.filter((card) => card.id !== optimisticId),
+      }));
+      setCreatingByStatus((previous) => ({ ...previous, [status]: false }));
+      return;
+    }
+
+    const createdTask = result.data;
+    const createdStatus = createdTask.properties.status;
+    const normalizedStatus: TaskStatus = createdStatus && isTaskStatus(createdStatus) ? createdStatus : status;
+
+    setBoardColumns((previous) => upsertCard(previous, {
+      id: createdTask.id,
+      title: createdTask.properties.title?.trim() || title,
+      status: normalizedStatus,
+      priority: createdTask.properties.priority,
+      dueDate: createdTask.properties.due_date,
+      assignee: createdTask.properties.assigned_to,
+    }));
+
+    setCreatingByStatus((previous) => ({ ...previous, [status]: false }));
+  };
+
+  const handleUpdateTask = async (taskId: string, payload: { title?: string; status?: TaskStatus }) => {
+    const response = await fetch(`/api/blocks/${taskId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    const result = (await response.json()) as ApiResponse<BlockApiData>;
+
+    if (!response.ok || !result.data) {
+      return;
+    }
+
+    const updatedTask = result.data;
+    const updatedStatus = updatedTask.properties.status;
+    const nextStatus: TaskStatus = updatedStatus && isTaskStatus(updatedStatus) ? updatedStatus : "todo";
+
+    setBoardColumns((previous) => upsertCard(previous, {
+      id: updatedTask.id,
+      title: updatedTask.properties.title?.trim() || "Bez tytułu",
+      status: nextStatus,
+      priority: updatedTask.properties.priority,
+      dueDate: updatedTask.properties.due_date,
+      assignee: updatedTask.properties.assigned_to,
+    }));
+  };
+
+  const handleDeleteTask = async (taskId: string) => {
+    const snapshot = boardColumns;
+
+    setBoardColumns((previous) => ({
+      todo: previous.todo.filter((card) => card.id !== taskId),
+      in_progress: previous.in_progress.filter((card) => card.id !== taskId),
+      done: previous.done.filter((card) => card.id !== taskId),
+    }));
+
+    const response = await fetch(`/api/blocks/${taskId}`, {
+      method: "DELETE",
+    });
+
+    const result = (await response.json()) as ApiResponse<{ id: string }>;
+
+    if (!response.ok || !result.data) {
+      setBoardColumns(snapshot);
+    }
+  };
+
   return (
     <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-      {COLUMN_ORDER.map((status) => (
-        <KanbanColumn key={status} title={COLUMN_TITLES[status]} workspaceSlug={workspaceSlug} cards={columns[status]} />
+      {TASK_STATUSES.map((status) => (
+        <KanbanColumn
+          key={status}
+          title={COLUMN_TITLES[status]}
+          status={status}
+          workspaceSlug={workspaceSlug}
+          cards={boardColumns[status]}
+          isCreating={creatingByStatus[status]}
+          onCreateTask={handleCreateTask}
+          onUpdateTask={handleUpdateTask}
+          onDeleteTask={handleDeleteTask}
+        />
       ))}
     </div>
   );

--- a/src/components/board/KanbanCard.tsx
+++ b/src/components/board/KanbanCard.tsx
@@ -1,16 +1,19 @@
 import Link from "next/link";
-import { CalendarDays, Flag, User } from "lucide-react";
+import { useState } from "react";
+import { CalendarDays, Flag, Pencil, Trash2, User } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { KanbanTaskCard } from "@/components/board/KanbanColumn";
+import type { TaskStatus } from "@/lib/db/types";
 
 interface KanbanCardProps {
-  blockId: string;
   workspaceSlug: string;
-  title: string;
-  priority?: "low" | "medium" | "high" | "urgent";
-  dueDate?: string;
-  assignee?: string;
+  card: KanbanTaskCard;
+  onUpdateTask: (taskId: string, payload: { title?: string; status?: TaskStatus }) => Promise<void>;
+  onDeleteTask: (taskId: string) => Promise<void>;
 }
 
-const PRIORITY_LABELS: Record<NonNullable<KanbanCardProps["priority"]>, string> = {
+const PRIORITY_LABELS: Record<NonNullable<KanbanTaskCard["priority"]>, string> = {
   low: "Low",
   medium: "Medium",
   high: "High",
@@ -47,30 +50,94 @@ function formatAssignee(assignee?: string): string {
   return `${assignee.slice(0, 8)}…`;
 }
 
-export function KanbanCard({ blockId, workspaceSlug, title, priority, dueDate, assignee }: KanbanCardProps) {
+export function KanbanCard({ workspaceSlug, card, onUpdateTask, onDeleteTask }: KanbanCardProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [title, setTitle] = useState(card.title);
+  const [status, setStatus] = useState<TaskStatus>(card.status);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSave = async () => {
+    const trimmedTitle = title.trim();
+
+    if (!trimmedTitle) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    await onUpdateTask(card.id, { title: trimmedTitle, status });
+    setIsSubmitting(false);
+    setIsEditing(false);
+  };
+
+  const handleDelete = async () => {
+    setIsSubmitting(true);
+    await onDeleteTask(card.id);
+    setIsSubmitting(false);
+  };
+
   return (
-    <Link
-      href={`/${workspaceSlug}/block/${blockId}`}
-      className="block rounded-lg border border-border-subtle bg-bg-surface p-3 transition-all duration-150 hover:-translate-y-px hover:border-border-default hover:bg-bg-elevated hover:shadow-md"
+    <div
+      className="rounded-lg border border-border-subtle bg-bg-surface p-3 transition-all duration-150 hover:-translate-y-px hover:border-border-default hover:bg-bg-elevated hover:shadow-md"
+      data-optimistic={card.isOptimistic ? "true" : "false"}
     >
-      <p className="line-clamp-2 text-sm font-medium text-content-primary">{title}</p>
+      <Link href={`/${workspaceSlug}/block/${card.id}`} className="block">
+        <p className="line-clamp-2 text-sm font-medium text-content-primary">{card.title}</p>
 
-      <div className="mt-3 space-y-1.5 text-xs text-content-muted">
-        <div className="flex items-center gap-1.5">
-          <Flag className="h-3.5 w-3.5" aria-hidden="true" />
-          <span>{priority ? PRIORITY_LABELS[priority] : "Brak priorytetu"}</span>
-        </div>
+        <div className="mt-3 space-y-1.5 text-xs text-content-muted">
+          <div className="flex items-center gap-1.5">
+            <Flag className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>{card.priority ? PRIORITY_LABELS[card.priority] : "Brak priorytetu"}</span>
+          </div>
 
-        <div className="flex items-center gap-1.5">
-          <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
-          <span>{formatDueDate(dueDate)}</span>
-        </div>
+          <div className="flex items-center gap-1.5">
+            <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>{formatDueDate(card.dueDate)}</span>
+          </div>
 
-        <div className="flex items-center gap-1.5">
-          <User className="h-3.5 w-3.5" aria-hidden="true" />
-          <span>{formatAssignee(assignee)}</span>
+          <div className="flex items-center gap-1.5">
+            <User className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>{formatAssignee(card.assignee)}</span>
+          </div>
         </div>
-      </div>
-    </Link>
+      </Link>
+
+      {!card.isOptimistic ? (
+        <>
+          {isEditing ? (
+            <div className="mt-2 space-y-2 rounded-md border border-border-subtle bg-bg-base p-2">
+              <Input value={title} onChange={(event) => setTitle(event.target.value)} />
+              <select
+                value={status}
+                onChange={(event) => setStatus(event.target.value as TaskStatus)}
+                className="w-full rounded-md border border-border-default bg-bg-base px-2 py-1.5 text-xs text-content-primary outline-none ring-offset-bg-base focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <option value="todo">Todo</option>
+                <option value="in_progress">In Progress</option>
+                <option value="done">Done</option>
+              </select>
+              <div className="flex justify-end gap-2">
+                <Button type="button" size="sm" variant="ghost" onClick={() => setIsEditing(false)} disabled={isSubmitting}>
+                  Cancel
+                </Button>
+                <Button type="button" size="sm" onClick={handleSave} disabled={isSubmitting || !title.trim()}>
+                  Save
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="mt-2 flex justify-end gap-1">
+              <Button type="button" size="icon" variant="ghost" className="h-7 w-7" onClick={() => setIsEditing(true)}>
+                <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
+                <span className="sr-only">Edit task</span>
+              </Button>
+              <Button type="button" size="icon" variant="ghost" className="h-7 w-7" onClick={handleDelete} disabled={isSubmitting}>
+                <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                <span className="sr-only">Delete task</span>
+              </Button>
+            </div>
+          )}
+        </>
+      ) : null}
+    </div>
   );
 }

--- a/src/components/board/KanbanColumn.tsx
+++ b/src/components/board/KanbanColumn.tsx
@@ -1,22 +1,61 @@
-import { Plus } from "lucide-react";
+import { useState } from "react";
+import { Check, Plus, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { KanbanCard } from "@/components/board/KanbanCard";
+import type { TaskStatus } from "@/lib/db/types";
 
-interface KanbanTaskCard {
+export interface KanbanTaskCard {
   id: string;
   title: string;
+  status: TaskStatus;
   priority?: "low" | "medium" | "high" | "urgent";
   dueDate?: string;
   assignee?: string;
+  isOptimistic?: boolean;
+}
+
+interface UpdateTaskPayload {
+  title?: string;
+  status?: TaskStatus;
 }
 
 interface KanbanColumnProps {
   title: string;
+  status: TaskStatus;
   workspaceSlug: string;
   cards: KanbanTaskCard[];
+  isCreating: boolean;
+  onCreateTask: (status: TaskStatus, title: string) => Promise<void>;
+  onUpdateTask: (taskId: string, payload: UpdateTaskPayload) => Promise<void>;
+  onDeleteTask: (taskId: string) => Promise<void>;
 }
 
-export function KanbanColumn({ title, workspaceSlug, cards }: KanbanColumnProps) {
+export function KanbanColumn({
+  title,
+  status,
+  workspaceSlug,
+  cards,
+  isCreating,
+  onCreateTask,
+  onUpdateTask,
+  onDeleteTask,
+}: KanbanColumnProps) {
+  const [isAdding, setIsAdding] = useState(false);
+  const [newTitle, setNewTitle] = useState("");
+
+  const handleCreateTask = async () => {
+    const trimmedTitle = newTitle.trim();
+
+    if (!trimmedTitle) {
+      return;
+    }
+
+    await onCreateTask(status, trimmedTitle);
+    setNewTitle("");
+    setIsAdding(false);
+  };
+
   return (
     <section className="flex min-h-[420px] flex-col rounded-xl border border-border-subtle bg-bg-base p-3">
       <div className="mb-3 flex items-center justify-between px-1">
@@ -26,29 +65,59 @@ export function KanbanColumn({ title, workspaceSlug, cards }: KanbanColumnProps)
 
       <div className="flex flex-1 flex-col gap-2">
         {cards.length === 0 ? (
-          <div className="flex flex-1 flex-col items-center justify-center rounded-lg border border-dashed border-border-subtle bg-bg-surface/60 px-4 text-center">
+          <div className="flex flex-1 items-center justify-center rounded-lg border border-dashed border-border-subtle bg-bg-surface/60 px-4 text-center">
             <p className="text-sm text-content-muted">Brak zadań w kolumnie.</p>
-            <Button type="button" variant="secondary" size="sm" className="mt-3 gap-1.5" disabled>
-              <Plus className="h-4 w-4" aria-hidden="true" />
-              Dodaj zadanie
-            </Button>
           </div>
         ) : (
           cards.map((card) => (
             <KanbanCard
               key={card.id}
-              blockId={card.id}
+              card={card}
               workspaceSlug={workspaceSlug}
-              title={card.title}
-              priority={card.priority}
-              dueDate={card.dueDate}
-              assignee={card.assignee}
+              onUpdateTask={onUpdateTask}
+              onDeleteTask={onDeleteTask}
             />
           ))
+        )}
+      </div>
+
+      <div className="mt-3 border-t border-border-subtle pt-3">
+        {isAdding ? (
+          <div className="space-y-2">
+            <Input
+              value={newTitle}
+              onChange={(event) => setNewTitle(event.target.value)}
+              placeholder="Task title"
+              aria-label="Task title"
+              autoFocus
+            />
+            <div className="flex items-center gap-2">
+              <Button type="button" size="sm" onClick={handleCreateTask} disabled={isCreating || !newTitle.trim()}>
+                <Check className="h-4 w-4" aria-hidden="true" />
+                Create
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setIsAdding(false);
+                  setNewTitle("");
+                }}
+                disabled={isCreating}
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+                Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <Button type="button" variant="ghost" size="sm" className="w-full justify-start gap-1.5" onClick={() => setIsAdding(true)}>
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            + Add task
+          </Button>
         )}
       </div>
     </section>
   );
 }
-
-export type { KanbanTaskCard };


### PR DESCRIPTION
### Motivation
- Dodać możliwość tworzenia, edycji i usuwania zadań (bloków typu `task`) bez tworzenia osobnych tabel, zgodnie z unified block modelem.
- Wprowadzić inline tworzenie zadań z poziomu kolumny oraz edycję/usuwanie z poziomu karty z optymistycznym UI.

### Description
- Dodano route handlers API: `POST /api/blocks` do tworzenia bloków `type='task'` z walidacją (tytuł wymagany, status z `TASK_STATUSES`) i sprawdzeniem członkostwa w workspace poprzez `workspace_members` (`src/app/api/blocks/route.ts`).
- Dodano route handlers `PATCH /api/blocks/[id]` i `DELETE /api/blocks/[id]` z weryfikacją dostępu do taska i walidacją danych (tytuł, status) (`src/app/api/blocks/[id]/route.ts`).
- Przepisano Kanban na komponent kliencki i dodano mutacje z optymistycznym update przy tworzeniu i usuwaniu (rollback przy błędzie), oraz obsługę aktualizacji zadania (title/status) (`src/components/board/KanbanBoard.tsx`).
- Dodano inline tworzenie (`+ Add task`) w stopce kolumny oraz formularz tworzenia, edycji i przycisk usuwania na karcie; zmodyfikowano typy kart i przepływ danych (`src/components/board/KanbanColumn.tsx`, `src/components/board/KanbanCard.tsx`).
- Zaktualizowano stronę boarda, aby mapować `status` z properties i przekazywać `workspaceId`/`projectId` do frontu potrzebne do mutacji (`src/app/(dashboard)/[workspaceSlug]/board/[projectId]/page.tsx`).

### Testing
- `npm run build` — build przeszedł pomyślnie (TypeScript / Next.js compile ok) and routes were discovered in build output. (succeeded)
- Uruchomienie deweloperskie `npm run dev -- --port 3000` uruchomiło aplikację, jednak podczas renderowania wymagana jest konfiguracja Supabase env (`NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY`) co spowodowało błąd renderu stron zależnych od supabase (runtime env missing). (dev started, runtime env error)
- Próba automatycznego zrzutu przeglądarki przez Playwright wykonała się i wygenerowała artifact z widokiem strony głównej (przy braku pełnej konfiguracji Supabase). (succeeded — screenshot artifact)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699feb012b3883309de4a61182cbb799)