### PR TITLE
feat: drag & drop kart Kanban z optimistic update

### DIFF
--- a/src/app/(dashboard)/[workspaceSlug]/board/[projectId]/page.tsx
+++ b/src/app/(dashboard)/[workspaceSlug]/board/[projectId]/page.tsx
@@ -18,6 +18,7 @@ interface TaskBlockProperties {
 
 interface TaskBlock {
   id: string;
+  position: number;
   properties: TaskBlockProperties;
 }
 
@@ -75,7 +76,7 @@ export default async function ProjectBoardPage({ params }: ProjectBoardPageProps
 
   const { data: tasks } = await supabase
     .from("blocks")
-    .select("id, properties")
+    .select("id, properties, position")
     .eq("workspace_id", workspace.id)
     .eq("project_id", project.id)
     .eq("type", "task")
@@ -94,6 +95,7 @@ export default async function ProjectBoardPage({ params }: ProjectBoardPageProps
       id: task.id,
       title: task.properties?.title?.trim() || "Bez tytułu",
       status,
+      position: task.position,
       priority: task.properties?.priority,
       dueDate: task.properties?.due_date,
       assignee: task.properties?.assigned_to,

--- a/src/app/api/blocks/route.ts
+++ b/src/app/api/blocks/route.ts
@@ -84,7 +84,7 @@ export async function POST(request: Request) {
         status: body.status,
       },
     })
-    .select("id, properties")
+    .select("id, properties, position")
     .single();
 
   if (error || !data) {

--- a/src/components/board/KanbanBoard.tsx
+++ b/src/components/board/KanbanBoard.tsx
@@ -1,6 +1,19 @@
 "use client";
 
-import { useState } from "react";
+import {
+  closestCorners,
+  DndContext,
+  DragOverlay,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import { arrayMove } from "@dnd-kit/sortable";
+import { useMemo, useState } from "react";
+import { KanbanCard } from "@/components/board/KanbanCard";
 import { KanbanColumn, type KanbanTaskCard } from "@/components/board/KanbanColumn";
 import { TASK_STATUSES, type TaskStatus } from "@/lib/db/types";
 
@@ -18,6 +31,7 @@ interface ApiResponse<T> {
 
 interface BlockApiData {
   id: string;
+  position?: number;
   properties: {
     title?: string;
     status?: TaskStatus;
@@ -50,24 +64,136 @@ function upsertCard(
     done: columns.done.filter((card) => !idsToRemove.has(card.id)),
   };
 
-  nextColumns[nextCard.status] = [nextCard, ...nextColumns[nextCard.status]];
+  nextColumns[nextCard.status] = [nextCard, ...nextColumns[nextCard.status]].map((card, index) => ({
+    ...card,
+    position: index + 1,
+  }));
 
   return nextColumns;
 }
 
+function findTaskStatusById(columns: Record<TaskStatus, KanbanTaskCard[]>, id: string): TaskStatus | null {
+  for (const status of TASK_STATUSES) {
+    if (columns[status].some((card) => card.id === id)) {
+      return status;
+    }
+  }
+
+  return null;
+}
+
+function normalizeColumnPositions(cards: KanbanTaskCard[]) {
+  return cards.map((card, index) => ({ ...card, position: index + 1 }));
+}
+
+function moveTask(
+  columns: Record<TaskStatus, KanbanTaskCard[]>,
+  taskId: string,
+  overId: string,
+): { nextColumns: Record<TaskStatus, KanbanTaskCard[]>; movedTask: KanbanTaskCard | null } {
+  const fromStatus = findTaskStatusById(columns, taskId);
+
+  if (!fromStatus) {
+    return { nextColumns: columns, movedTask: null };
+  }
+
+  const toStatus = overId.startsWith("column:") ? (overId.replace("column:", "") as TaskStatus) : findTaskStatusById(columns, overId);
+
+  if (!toStatus || !isTaskStatus(toStatus)) {
+    return { nextColumns: columns, movedTask: null };
+  }
+
+  const sourceCards = [...columns[fromStatus]];
+  const sourceIndex = sourceCards.findIndex((card) => card.id === taskId);
+
+  if (sourceIndex < 0) {
+    return { nextColumns: columns, movedTask: null };
+  }
+
+  const movingCard = sourceCards[sourceIndex];
+
+  if (fromStatus === toStatus && !overId.startsWith("column:")) {
+    const overIndex = sourceCards.findIndex((card) => card.id === overId);
+
+    if (overIndex < 0 || overIndex === sourceIndex) {
+      return { nextColumns: columns, movedTask: null };
+    }
+
+    const reordered = normalizeColumnPositions(arrayMove(sourceCards, sourceIndex, overIndex));
+
+    return {
+      nextColumns: {
+        ...columns,
+        [fromStatus]: reordered,
+      },
+      movedTask: reordered[overIndex],
+    };
+  }
+
+  const nextSource = sourceCards.filter((card) => card.id !== taskId);
+  const destinationCards = fromStatus === toStatus ? nextSource : [...columns[toStatus]];
+
+  const insertIndex = overId.startsWith("column:")
+    ? destinationCards.length
+    : Math.max(destinationCards.findIndex((card) => card.id === overId), 0);
+
+  const nextMovingCard: KanbanTaskCard = {
+    ...movingCard,
+    status: toStatus,
+  };
+
+  const nextDestination = [...destinationCards];
+  nextDestination.splice(insertIndex, 0, nextMovingCard);
+
+  const normalizedSource = normalizeColumnPositions(nextSource);
+  const normalizedDestination = normalizeColumnPositions(nextDestination);
+  const movedTask = normalizedDestination.find((card) => card.id === taskId) ?? null;
+
+  return {
+    nextColumns: {
+      ...columns,
+      [fromStatus]: normalizedSource,
+      [toStatus]: normalizedDestination,
+    },
+    movedTask,
+  };
+}
+
 export function KanbanBoard({ workspaceSlug, workspaceId, projectId, columns }: KanbanBoardProps) {
   const [boardColumns, setBoardColumns] = useState(columns);
+  const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
   const [creatingByStatus, setCreatingByStatus] = useState<Record<TaskStatus, boolean>>({
     todo: false,
     in_progress: false,
     done: false,
   });
 
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 180, tolerance: 5 } }),
+  );
+
+  const activeTask = useMemo(() => {
+    if (!activeTaskId) {
+      return null;
+    }
+
+    for (const status of TASK_STATUSES) {
+      const foundCard = boardColumns[status].find((card) => card.id === activeTaskId);
+
+      if (foundCard) {
+        return foundCard;
+      }
+    }
+
+    return null;
+  }, [activeTaskId, boardColumns]);
+
   const handleCreateTask = async (status: TaskStatus, title: string) => {
     const optimisticId = `optimistic-${Date.now()}`;
 
     setCreatingByStatus((previous) => ({ ...previous, [status]: true }));
-    setBoardColumns((previous) => upsertCard(previous, { id: optimisticId, title, status, isOptimistic: true }));
+    setBoardColumns((previous) => upsertCard(previous, { id: optimisticId, title, status, position: 0, isOptimistic: true }));
 
     const response = await fetch("/api/blocks", {
       method: "POST",
@@ -98,6 +224,7 @@ export function KanbanBoard({ workspaceSlug, workspaceId, projectId, columns }: 
           id: createdTask.id,
           title: createdTask.properties.title?.trim() || title,
           status: normalizedStatus,
+          position: typeof createdTask.position === "number" ? createdTask.position : 1,
           priority: createdTask.properties.priority,
           dueDate: createdTask.properties.due_date,
           assignee: createdTask.properties.assigned_to,
@@ -130,6 +257,7 @@ export function KanbanBoard({ workspaceSlug, workspaceId, projectId, columns }: 
       id: updatedTask.id,
       title: updatedTask.properties.title?.trim() || "Bez tytułu",
       status: nextStatus,
+      position: typeof updatedTask.position === "number" ? updatedTask.position : 1,
       priority: updatedTask.properties.priority,
       dueDate: updatedTask.properties.due_date,
       assignee: updatedTask.properties.assigned_to,
@@ -156,21 +284,88 @@ export function KanbanBoard({ workspaceSlug, workspaceId, projectId, columns }: 
     }
   };
 
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveTaskId(String(event.active.id));
+  };
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    setActiveTaskId(null);
+
+    if (!event.over) {
+      return;
+    }
+
+    const activeId = String(event.active.id);
+    const overId = String(event.over.id);
+
+    if (activeId === overId) {
+      return;
+    }
+
+    const snapshot = boardColumns;
+    const { nextColumns, movedTask } = moveTask(boardColumns, activeId, overId);
+
+    if (!movedTask) {
+      return;
+    }
+
+    setBoardColumns(nextColumns);
+
+    const response = await fetch(`/api/blocks/${activeId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: movedTask.status, position: movedTask.position }),
+    });
+
+    const result = (await response.json()) as ApiResponse<BlockApiData>;
+
+    if (!response.ok || !result.data) {
+      setBoardColumns(snapshot);
+    }
+  };
+
+  const handleDragCancel = () => {
+    setActiveTaskId(null);
+  };
+
   return (
-    <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-      {TASK_STATUSES.map((status) => (
-        <KanbanColumn
-          key={status}
-          title={COLUMN_TITLES[status]}
-          status={status}
-          workspaceSlug={workspaceSlug}
-          cards={boardColumns[status]}
-          isCreating={creatingByStatus[status]}
-          onCreateTask={handleCreateTask}
-          onUpdateTask={handleUpdateTask}
-          onDeleteTask={handleDeleteTask}
-        />
-      ))}
-    </div>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCorners}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        {TASK_STATUSES.map((status) => (
+          <KanbanColumn
+            key={status}
+            title={COLUMN_TITLES[status]}
+            status={status}
+            workspaceSlug={workspaceSlug}
+            cards={boardColumns[status]}
+            isCreating={creatingByStatus[status]}
+            onCreateTask={handleCreateTask}
+            onUpdateTask={handleUpdateTask}
+            onDeleteTask={handleDeleteTask}
+          />
+        ))}
+      </div>
+
+      <DragOverlay>
+        {activeTask ? (
+          <div className="w-[320px] cursor-grabbing">
+            <KanbanCard
+              workspaceSlug={workspaceSlug}
+              card={activeTask}
+              onDeleteTask={async () => undefined}
+              onUpdateTask={async () => undefined}
+              hideActions
+              disableLink
+            />
+          </div>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
   );
 }

--- a/src/components/board/KanbanCard.tsx
+++ b/src/components/board/KanbanCard.tsx
@@ -11,6 +11,8 @@ interface KanbanCardProps {
   card: KanbanTaskCard;
   onUpdateTask: (taskId: string, payload: { title?: string; status?: TaskStatus }) => Promise<void>;
   onDeleteTask: (taskId: string) => Promise<void>;
+  hideActions?: boolean;
+  disableLink?: boolean;
 }
 
 const PRIORITY_LABELS: Record<NonNullable<KanbanTaskCard["priority"]>, string> = {
@@ -50,7 +52,7 @@ function formatAssignee(assignee?: string): string {
   return `${assignee.slice(0, 8)}…`;
 }
 
-export function KanbanCard({ workspaceSlug, card, onUpdateTask, onDeleteTask }: KanbanCardProps) {
+export function KanbanCard({ workspaceSlug, card, onUpdateTask, onDeleteTask, hideActions = false, disableLink = false }: KanbanCardProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [title, setTitle] = useState(card.title);
   const [status, setStatus] = useState<TaskStatus>(card.status);
@@ -75,33 +77,37 @@ export function KanbanCard({ workspaceSlug, card, onUpdateTask, onDeleteTask }: 
     setIsSubmitting(false);
   };
 
+  const content = (
+    <>
+      <p className="line-clamp-2 text-sm font-medium text-content-primary">{card.title}</p>
+
+      <div className="mt-3 space-y-1.5 text-xs text-content-muted">
+        <div className="flex items-center gap-1.5">
+          <Flag className="h-3.5 w-3.5" aria-hidden="true" />
+          <span>{card.priority ? PRIORITY_LABELS[card.priority] : "Brak priorytetu"}</span>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+          <span>{formatDueDate(card.dueDate)}</span>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <User className="h-3.5 w-3.5" aria-hidden="true" />
+          <span>{formatAssignee(card.assignee)}</span>
+        </div>
+      </div>
+    </>
+  );
+
   return (
     <div
       className="rounded-lg border border-border-subtle bg-bg-surface p-3 transition-all duration-150 hover:-translate-y-px hover:border-border-default hover:bg-bg-elevated hover:shadow-md"
       data-optimistic={card.isOptimistic ? "true" : "false"}
     >
-      <Link href={`/${workspaceSlug}/block/${card.id}`} className="block">
-        <p className="line-clamp-2 text-sm font-medium text-content-primary">{card.title}</p>
+      {disableLink ? content : <Link href={`/${workspaceSlug}/block/${card.id}`} className="block">{content}</Link>}
 
-        <div className="mt-3 space-y-1.5 text-xs text-content-muted">
-          <div className="flex items-center gap-1.5">
-            <Flag className="h-3.5 w-3.5" aria-hidden="true" />
-            <span>{card.priority ? PRIORITY_LABELS[card.priority] : "Brak priorytetu"}</span>
-          </div>
-
-          <div className="flex items-center gap-1.5">
-            <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
-            <span>{formatDueDate(card.dueDate)}</span>
-          </div>
-
-          <div className="flex items-center gap-1.5">
-            <User className="h-3.5 w-3.5" aria-hidden="true" />
-            <span>{formatAssignee(card.assignee)}</span>
-          </div>
-        </div>
-      </Link>
-
-      {!card.isOptimistic ? (
+      {!card.isOptimistic && !hideActions ? (
         <>
           {isEditing ? (
             <div className="mt-2 space-y-2 rounded-md border border-border-subtle bg-bg-base p-2">


### PR DESCRIPTION
### Motivation
- Umożliwić przeciąganie kart między kolumnami i zmianę kolejności z płynnym UX (floating card) i szybką aktualizacją UI.
- Wprowadzić optimistic updates dla operacji drag&drop, z możliwością rollbacku przy błędzie API.

### Description
- Zintegrowano `@dnd-kit/core` i `@dnd-kit/sortable` w `KanbanBoard` i dodano `DndContext`, sensory, `DragOverlay` oraz logikę startu/końca przeciągania.  
- Dodano sortowanie kart i droppable kolumny w `KanbanColumn` używając `useDroppable`, `SortableContext` i `useSortable` oraz komponent `SortableTaskCard`.  
- Wprowadzono funkcję przenoszenia `moveTask` i normalizację pozycji `position` w frontendzie, a `KanbanBoard` wykonuje optimistic update przy upuszczeniu i rollback do snapshotu gdy API zwróci błąd.  
- Rozszerzono `KanbanCard` o propsy `hideActions` i `disableLink` by użyć tej samej karty w `DragOverlay` bez akcji i nawigacji.  
- API zmodyfikowane tak, by obsługiwać i zwracać `position`: `POST /api/blocks` zwraca teraz `position`, a `PATCH /api/blocks/[id]` przyjmuje `position`, waliduje je i aktualizuje kolumnę; zmiany mapowane są też na stronie tablicy projektu (`page.tsx`).

### Testing
- `npm run build` zakończył się powodzeniem (kompilacja Next.js i generowanie stron) — ✅.  
- `npm run lint` nie przeszedł z powodu braku modułu `eslint-config-next/core-web-vitals` w środowisku, więc linter nie uruchomił się — ⚠️.  
- `npm run dev` uruchomił serwer lokalnie, ale żądanie `GET /` zwróciło 500 w tym środowisku z powodu brakujących zmiennych `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY`; serwer i widok Kanban były jednak dostępne po dostarczeniu odpowiednich zmiennych — ⚠️.  
- Wykonano zrzut ekranu środowiska dev i dołączono artefakt testowy obrazu pokazujący stronę aplikacji podczas developmentu.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0252e38648330b8e3098f1bfcecf9)