### PR TITLE
Filtrowanie i sortowanie kart na tablicy Kanban

### DIFF
--- a/src/components/board/KanbanColumn.tsx
+++ b/src/components/board/KanbanColumn.tsx
@@ -30,6 +30,7 @@ interface KanbanColumnProps {
   workspaceSlug: string;
   cards: KanbanTaskCard[];
   isCreating: boolean;
+  disableDrag: boolean;
   onCreateTask: (status: TaskStatus, title: string) => Promise<void>;
   onUpdateTask: (taskId: string, payload: UpdateTaskPayload) => Promise<void>;
   onDeleteTask: (taskId: string) => Promise<void>;
@@ -38,18 +39,20 @@ interface KanbanColumnProps {
 function SortableTaskCard({
   card,
   workspaceSlug,
+  disableDrag,
   onUpdateTask,
   onDeleteTask,
 }: {
   card: KanbanTaskCard;
   workspaceSlug: string;
+  disableDrag: boolean;
   onUpdateTask: (taskId: string, payload: UpdateTaskPayload) => Promise<void>;
   onDeleteTask: (taskId: string) => Promise<void>;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: card.id,
     data: { type: "task", status: card.status },
-    disabled: card.isOptimistic,
+    disabled: card.isOptimistic || disableDrag,
   });
 
   return (
@@ -79,6 +82,7 @@ export function KanbanColumn({
   workspaceSlug,
   cards,
   isCreating,
+  disableDrag,
   onCreateTask,
   onUpdateTask,
   onDeleteTask,
@@ -125,6 +129,7 @@ export function KanbanColumn({
                 key={card.id}
                 card={card}
                 workspaceSlug={workspaceSlug}
+                disableDrag={disableDrag}
                 onUpdateTask={onUpdateTask}
                 onDeleteTask={onDeleteTask}
               />

--- a/src/lib/stores/board-filters-store.ts
+++ b/src/lib/stores/board-filters-store.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+
+export type BoardSortOption = "position" | "due_date" | "priority";
+export type BoardPriorityFilter = "all" | "high" | "medium" | "low";
+
+interface BoardFiltersState {
+  searchQuery: string;
+  priority: BoardPriorityFilter;
+  assignee: string;
+  sortBy: BoardSortOption;
+  setSearchQuery: (value: string) => void;
+  setPriority: (value: BoardPriorityFilter) => void;
+  setAssignee: (value: string) => void;
+  setSortBy: (value: BoardSortOption) => void;
+  resetFilters: () => void;
+}
+
+const DEFAULT_FILTERS = {
+  searchQuery: "",
+  priority: "all" as const,
+  assignee: "all",
+  sortBy: "position" as const,
+};
+
+export const useBoardFiltersStore = create<BoardFiltersState>((set) => ({
+  ...DEFAULT_FILTERS,
+  setSearchQuery: (value) => set({ searchQuery: value }),
+  setPriority: (value) => set({ priority: value }),
+  setAssignee: (value) => set({ assignee: value }),
+  setSortBy: (value) => set({ sortBy: value }),
+  resetFilters: () => set(DEFAULT_FILTERS),
+}));
+


### PR DESCRIPTION
### Motivation
- Umożliwić przeszukiwanie, filtrowanie i sortowanie kart na tablicy Kanban oraz utrzymać stan filtrów poza komponentami.

### Description
- Dodano Zustand store `useBoardFiltersStore` z polami `searchQuery`, `priority`, `assignee`, `sortBy` oraz setterami i `resetFilters` (`src/lib/stores/board-filters-store.ts`).
- Dodano pasek narzędzi w `KanbanBoard` z wyszukiwarką tytułów, filtrem priorytetu, filtrem przypisanego użytkownika (w tym `unassigned`) i wyborem sortowania (`position` / `due_date` / `priority`) oraz przyciskiem resetu (`src/components/board/KanbanBoard.tsx`).
- Wprowadzone `visibleColumns` w `KanbanBoard` implementują klient-side filtrowanie i sortowanie per kolumna (sortowanie po pozycji, dacie i priorytecie z fallbackem do pozycji) oraz generowanie listy dostępnych assignee; dodano `PRIORITY_ORDER` i `SORT_OPTIONS` dla logiki sortowania.
- Wyłączono przeciąganie kart, gdy sortowanie nie jest `position` i przekazano `disableDrag` do `KanbanColumn` tak, by `useSortable` respektował tryb sortowania (`src/components/board/KanbanColumn.tsx`).

### Testing
- `npx tsc --noEmit` — zakończono pomyślnie.
- `npm run lint` — nieudane z powodu brakującego modułu w środowisku (`eslint-config-next/core-web-vitals`).
- Uruchomiono deweloperski serwer aplikacji `npm run dev` i Next.js wystartował lokalnie; próba automatycznego zrzutu ekranu przez Playwright nie powiodła się z powodu awarii Chromium w tym środowisku (SIGSEGV).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a026f224888330a5bd0b47186b3427)