### PR TITLE
chore: integrate BlockNote editor (#14)

### DIFF
--- a/src/app/blocknote-test/page.tsx
+++ b/src/app/blocknote-test/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { BlockNoteContent } from "@/lib/types/blocknote";
+
+const BlockNoteEditor = dynamic(
+  () => import("@/components/editor/BlockNoteEditor").then((mod) => mod.BlockNoteEditor),
+  { ssr: false },
+);
+
+const demoContent: BlockNoteContent = [
+  {
+    type: "heading",
+    props: { level: 2 },
+    content: "BlockNote integration test",
+  },
+  {
+    type: "paragraph",
+    content: "Ta strona służy do weryfikacji działania edytora BlockNote.",
+  },
+  {
+    type: "bulletListItem",
+    content: "Tryb dark zgodny z tokenami Monolith",
+  },
+  {
+    type: "bulletListItem",
+    content: "Obsługa JSON content przez TypeScript",
+  },
+];
+
+export default function BlockNoteTestPage() {
+  return (
+    <main className="min-h-screen bg-bg-base px-6 py-10 text-content-primary">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-4">
+        <h1 className="text-2xl font-semibold">BlockNote — strona testowa</h1>
+        <p className="text-content-secondary">
+          Sprawdź edycję treści, menu slash i formatowanie bloków.
+        </p>
+        <BlockNoteEditor initialContent={demoContent} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -109,3 +109,20 @@
   ::-webkit-scrollbar-thumb { @apply bg-border-default rounded-full; }
   ::-webkit-scrollbar-thumb:hover { @apply bg-border-strong; }
 }
+
+@layer components {
+  .bn-container {
+    background-color: var(--color-bg-surface);
+    color: var(--color-content-primary);
+  }
+
+  .bn-editor,
+  .bn-side-menu,
+  .bn-formatting-toolbar,
+  .bn-slash-menu,
+  .bn-suggestion-menu {
+    background-color: var(--color-bg-elevated);
+    border-color: var(--color-border-default);
+    color: var(--color-content-primary);
+  }
+}

--- a/src/components/editor/BlockNoteEditor.tsx
+++ b/src/components/editor/BlockNoteEditor.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useMemo } from "react";
+import { BlockNoteView } from "@blocknote/mantine";
+import { useCreateBlockNote } from "@blocknote/react";
+import type { BlockNoteContent } from "@/lib/types/blocknote";
+
+import "@blocknote/core/fonts/inter.css";
+import "@blocknote/mantine/style.css";
+
+interface BlockNoteEditorProps {
+  initialContent?: BlockNoteContent;
+  onChange?: (content: BlockNoteContent) => void;
+  editable?: boolean;
+}
+
+const DEFAULT_CONTENT: BlockNoteContent = [
+  {
+    type: "paragraph",
+    content: "Zacznij pisać…",
+  },
+];
+
+export function BlockNoteEditor({
+  initialContent,
+  onChange,
+  editable = true,
+}: BlockNoteEditorProps) {
+  const content = useMemo(
+    () => (initialContent && initialContent.length > 0 ? initialContent : DEFAULT_CONTENT),
+    [initialContent],
+  );
+
+  const editor = useCreateBlockNote({
+    initialContent: content,
+  });
+
+  return (
+    <div className="rounded-xl border border-border-default bg-bg-surface p-2">
+      <BlockNoteView
+        editor={editor}
+        theme="dark"
+        editable={editable}
+        onChange={() => {
+          onChange?.(editor.document);
+        }}
+      />
+    </div>
+  );
+}

--- a/src/lib/types/blocknote.ts
+++ b/src/lib/types/blocknote.ts
@@ -1,0 +1,7 @@
+import type { PartialBlock } from "@blocknote/core";
+
+export type BlockNoteContent = PartialBlock[];
+
+export interface BlockNoteDocument {
+  content: BlockNoteContent;
+}


### PR DESCRIPTION
### Motivation
- Dodać edytor blokowy BlockNote jako klientowy komponent, ponieważ BlockNote wymaga `use client` i nie może być renderowany w RSC/SSR.
- Zapewnić wstępną konfigurację trybu dark zgodną z tokenami designu Monolith.
- Udostępnić typy TypeScript dla JSON-owego contentu oraz prostą stronę testową do weryfikacji integracji.

### Description
- Dodano klientowy wrapper `BlockNoteEditor` w `src/components/editor/BlockNoteEditor.tsx` z `"use client"`, importami stylów BlockNote oraz `useCreateBlockNote` i `BlockNoteView` ustawionym na `theme="dark"`.
- Dodano typy TypeScript `BlockNoteContent` i `BlockNoteDocument` w `src/lib/types/blocknote.ts` oparte na `PartialBlock` z `@blocknote/core`.
- Dodano stronę testową `src/app/blocknote-test/page.tsx`, która ładuje edytor dynamicznie i klientowo (użycie `next/dynamic`/`ssr: false` oraz/ lub `"use client"` w pliku strony) i zawiera przykładowy `demoContent` do ręcznej weryfikacji UI i slash-menu.
- Zaktualizowano `src/app/globals.css` o drobne reguły stylów (`@layer components`) dopasowujące kontenery i menu BlockNote do dark tokenów Monolith.

### Testing
- Uruchomiono `npm run build`, który zakończył się pomyślnie (strona `/blocknote-test` poprawnie wygenerowana) ✅.
- Uruchomiono `npm run lint`, które zakończyło się błędem z powodu brakującego modułu w konfiguracji ESLint (`eslint-config-next/core-web-vitals`) ❌.
- Uruchomiono `npm run dev` i odwiedzono `http://localhost:3000/blocknote-test`, co potwierdziło poprawne uruchomienie edytora w przeglądarce lokalnej oraz wygenerowano screenshot testowy przy użyciu Playwright (artifact zapisany). ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a02856e1508330b33d4a419bd49ce6)