### PR TITLE
feat: open Kanban cards as full task pages

### DIFF
--- a/src/app/(dashboard)/[workspaceSlug]/block/[blockId]/page.tsx
+++ b/src/app/(dashboard)/[workspaceSlug]/block/[blockId]/page.tsx
@@ -77,7 +77,7 @@ export default async function WorkspaceBlockPage({ params }: BlockPageRouteProps
   }
 
   const { data: project } = block.project_id
-    ? await supabase.from("projects").select("name").eq("id", block.project_id).maybeSingle()
+    ? await supabase.from("projects").select("id, name").eq("id", block.project_id).maybeSingle()
     : { data: null };
 
   const { data: members } = await supabase
@@ -90,6 +90,7 @@ export default async function WorkspaceBlockPage({ params }: BlockPageRouteProps
       workspaceSlug={workspaceSlug}
       blockId={block.id}
       blockType={block.type}
+      projectId={project?.id ?? undefined}
       projectName={project?.name}
       initialTitle={block.properties?.title?.trim() || "Bez tytułu"}
       initialContent={Array.isArray(block.content) ? block.content : []}

--- a/src/app/(dashboard)/[workspaceSlug]/layout.tsx
+++ b/src/app/(dashboard)/[workspaceSlug]/layout.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { createServerClient } from "@/lib/supabase/server";
 import { Sidebar, SidebarSkeleton } from "@/components/layout/Sidebar";
 import { Navbar } from "@/components/layout/Navbar";
+import { ReactQueryProvider } from "@/components/providers/ReactQueryProvider";
 
 interface WorkspaceLayoutProps {
   children: React.ReactNode;
@@ -67,7 +68,7 @@ async function DashboardShell({ children, workspaceSlug }: DashboardShellProps) 
     .order("created_at", { ascending: true });
 
   return (
-    <>
+    <ReactQueryProvider>
       <Sidebar
         currentWorkspaceSlug={workspaceSlug}
         workspaceId={currentWorkspace.id}
@@ -78,7 +79,7 @@ async function DashboardShell({ children, workspaceSlug }: DashboardShellProps) 
         <Navbar workspaceName={currentWorkspace.name} userEmail={user.email ?? user.id} />
         <main className="flex-1 overflow-y-auto bg-bg-base">{children}</main>
       </div>
-    </>
+    </ReactQueryProvider>
   );
 }
 

--- a/src/components/providers/ReactQueryProvider.tsx
+++ b/src/components/providers/ReactQueryProvider.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode, useState } from "react";
+
+interface ReactQueryProviderProps {
+  children: ReactNode;
+}
+
+export function ReactQueryProvider({ children }: ReactQueryProviderProps) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30_000,
+          },
+        },
+      })
+  );
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/src/lib/react-query/query-keys.ts
+++ b/src/lib/react-query/query-keys.ts
@@ -1,0 +1,4 @@
+export const blockQueryKey = (blockId: string) => ["block", blockId] as const;
+
+export const boardColumnsQueryKey = (workspaceSlug: string, projectId: string) =>
+  ["board-columns", workspaceSlug, projectId] as const;


### PR DESCRIPTION
### Motivation
- Enable opening a Kanban card as a full-page Block editor and keep board/card state synchronized across navigation. 
- Prefetch block data on hover to make navigation feel instant and reduce perceived latency. 
- Provide a clear breadcrumb back to the originating board so users can easily return to the Kanban view. 
- Keep Kanban column state in a shared cache so edits made in the Block page are reflected immediately on the board.

### Description
- Added a workspace-scoped React Query provider and shared query keys to coordinate caches (`src/components/providers/ReactQueryProvider.tsx`, `src/lib/react-query/query-keys.ts`) and wrapped the workspace layout with the provider (`src/app/(dashboard)/[workspaceSlug]/layout.tsx`). 
- Implemented block prefetch on Kanban card hover/focus using React Query `prefetchQuery` in `src/components/board/KanbanCard.tsx` and added a `GET /api/blocks/[id]` endpoint to support that prefetch (`src/app/api/blocks/[id]/route.ts`). 
- Persisted board column state into React Query cache and kept it in sync from `KanbanBoard` by reading/writing `board-columns` cache keys (`src/components/board/KanbanBoard.tsx`). 
- Updated `BlockPage` to accept `projectId`, show a direct breadcrumb link "← Powrót do tablicy" targeting the originating board, and to update both the single-block cache and the board-columns cache after successful saves so the card is updated immediately (`src/components/block/BlockPage.tsx`, `src/app/(dashboard)/[workspaceSlug]/block/[blockId]/page.tsx`).

### Testing
- Ran `npx tsc --noEmit` to verify TypeScript types and compilation, which succeeded. 
- Ran `npm run lint`, which failed in this environment due to a missing module (`eslint-config-next/core-web-vitals`) unrelated to the change (environment issue). 
- Started the dev server with `npm run dev`; the server started, but runtime flows requiring Supabase failed due to missing environment variables (`NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY`), so full end-to-end authenticated flows were not validated. 
- Captured a browser screenshot during the dev run with Playwright: `artifacts/feature-16-home.png` as an environment-level visual check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a02f4c9290833098dee1c39f2524ed)