### PR TITLE
feat: open kanban card as full block page with dedicated drag handle

### DIFF
--- a/src/components/board/KanbanCard.tsx
+++ b/src/components/board/KanbanCard.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { CalendarDays, Flag, Pencil, Trash2, User } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -15,6 +15,7 @@ interface KanbanCardProps {
   onDeleteTask: (taskId: string) => Promise<void>;
   hideActions?: boolean;
   disableLink?: boolean;
+  dragHandle?: ReactNode;
 }
 
 const PRIORITY_LABELS: Record<NonNullable<KanbanTaskCard["priority"]>, string> = {
@@ -54,7 +55,15 @@ function formatAssignee(assignee?: string): string {
   return `${assignee.slice(0, 8)}…`;
 }
 
-export function KanbanCard({ workspaceSlug, card, onUpdateTask, onDeleteTask, hideActions = false, disableLink = false }: KanbanCardProps) {
+export function KanbanCard({
+  workspaceSlug,
+  card,
+  onUpdateTask,
+  onDeleteTask,
+  hideActions = false,
+  disableLink = false,
+  dragHandle,
+}: KanbanCardProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [title, setTitle] = useState(card.title);
   const [status, setStatus] = useState<TaskStatus>(card.status);
@@ -99,7 +108,10 @@ export function KanbanCard({ workspaceSlug, card, onUpdateTask, onDeleteTask, hi
 
   const content = (
     <>
-      <p className="line-clamp-2 text-sm font-medium text-content-primary">{card.title}</p>
+      <div className="flex items-start gap-2">
+        <p className="line-clamp-2 flex-1 text-sm font-medium text-content-primary">{card.title}</p>
+        {dragHandle ?? null}
+      </div>
 
       <div className="mt-3 space-y-1.5 text-xs text-content-muted">
         <div className="flex items-center gap-1.5">

--- a/src/components/board/KanbanColumn.tsx
+++ b/src/components/board/KanbanColumn.tsx
@@ -2,7 +2,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { useDroppable } from "@dnd-kit/core";
 import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { useState } from "react";
-import { Check, Plus, X } from "lucide-react";
+import { Check, GripVertical, Plus, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { KanbanCard } from "@/components/board/KanbanCard";
@@ -49,7 +49,7 @@ function SortableTaskCard({
   onUpdateTask: (taskId: string, payload: UpdateTaskPayload) => Promise<void>;
   onDeleteTask: (taskId: string) => Promise<void>;
 }) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({
     id: card.id,
     data: { type: "task", status: card.status },
     disabled: card.isOptimistic || disableDrag,
@@ -63,14 +63,26 @@ function SortableTaskCard({
         transition,
       }}
       className={isDragging ? "opacity-40" : undefined}
-      {...attributes}
-      {...listeners}
     >
       <KanbanCard
         card={card}
         workspaceSlug={workspaceSlug}
         onUpdateTask={onUpdateTask}
         onDeleteTask={onDeleteTask}
+        dragHandle={
+          !disableDrag ? (
+            <button
+              type="button"
+              ref={setActivatorNodeRef}
+              {...attributes}
+              {...listeners}
+              className="-mr-1 mt-0.5 inline-flex h-6 w-6 items-center justify-center rounded text-content-muted transition hover:bg-bg-base hover:text-content-primary"
+              aria-label="Przeciągnij kartę"
+            >
+              <GripVertical className="h-3.5 w-3.5" aria-hidden="true" />
+            </button>
+          ) : null
+        }
       />
     </div>
   );


### PR DESCRIPTION
### Motivation
- Kliknięcie karty Kanban musi otwierać pełną stronę bloku (`/[workspaceSlug]/block/[blockId]`) bez przypadkowego przechwycenia przez DnD. 
- Należało zachować istniejące prefetching danych bloku przy hover/focus (React Query) oraz synchronizację stanu pomiędzy `BlockPage` a kartą. 
- Rozwiązanie polega na wydzieleniu dedykowanego uchwytu drag-and-drop, aby separować akcję kliknięcia od rozpoczęcia przeciągania.

### Description
- Dodano opcjonalny slot `dragHandle` do komponentu `KanbanCard` i zmodyfikowano layout tytułu tak, by uchwyt mógł być renderowany obok tytułu bez blokowania całej karty. (plik: `src/components/board/KanbanCard.tsx`).
- Przeniesiono atrybuty/listenery `useSortable` z całej karty na activator/uchwyt przez `setActivatorNodeRef` w `SortableTaskCard`, dzięki czemu DnD jest inicjowane tylko przez dedykowany przycisk z ikoną `GripVertical`. (plik: `src/components/board/KanbanColumn.tsx`).
- Zabezpieczono, że link na karcie (`<Link href="/[workspaceSlug]/block/[blockId]">`) oraz istniejąca funkcja `prefetchQuery` przy `onMouseEnter`/`onFocus` pozostają nienaruszone, więc klik i prefetch działają jak wcześniej.
- Zmiany obejmują dodanie importu ikony `GripVertical` i przekazywanie uchwytu do `KanbanCard`; nie zmieniono logiki zapisywania/synchronizacji danych (również `BlockPage` nadal aktualizuje `React Query` keys).

### Testing
- Odpalenie produkcyjnego builda przez `npm run build` zakończyło się sukcesem (kompilacja TypeScript i generacja stron). ✅
- Uruchomienie deweloperskie przez `npm run dev` uruchomiło aplikację lokalnie do manualnej weryfikacji UI. ✅
- Zrobiono prosty test automatyczny (Playwright) który ładuje stronę główną i robi screenshot: skrypt odwiedził `http://127.0.0.1:3000` i wygenerował `artifacts/home.png`. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a04169e4ec833085f2308c82c4bb29)