### PR TITLE
feat: dodaj widok kalendarza miesięcznego z zadaniami (due_date)

### DIFF
--- a/src/app/(dashboard)/[workspaceSlug]/calendar/page.tsx
+++ b/src/app/(dashboard)/[workspaceSlug]/calendar/page.tsx
@@ -1,0 +1,126 @@
+import { notFound, redirect } from "next/navigation";
+import { CalendarPageClient, type CalendarTaskEvent, type CalendarWorkspaceProject } from "@/components/calendar/CalendarPageClient";
+import { createServerClient } from "@/lib/supabase/server";
+
+interface WorkspaceCalendarPageProps {
+  params: Promise<{ workspaceSlug: string }>;
+  searchParams: Promise<{ month?: string }>;
+}
+
+interface TaskBlockRow {
+  id: string;
+  properties: {
+    title?: string;
+    due_date?: string;
+    priority?: "low" | "medium" | "high" | "urgent";
+    status?: "todo" | "in_progress" | "done";
+  };
+}
+
+function resolveMonth(monthParam?: string): Date {
+  if (!monthParam) {
+    const now = new Date();
+    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  }
+
+  const match = monthParam.match(/^(\d{4})-(\d{2})$/);
+
+  if (!match) {
+    const now = new Date();
+    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  }
+
+  const year = Number(match[1]);
+  const monthIndex = Number(match[2]) - 1;
+
+  if (!Number.isInteger(year) || !Number.isInteger(monthIndex) || monthIndex < 0 || monthIndex > 11) {
+    const now = new Date();
+    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  }
+
+  return new Date(Date.UTC(year, monthIndex, 1));
+}
+
+function formatMonthKey(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
+}
+
+export default async function WorkspaceCalendarPage({ params, searchParams }: WorkspaceCalendarPageProps) {
+  const { workspaceSlug } = await params;
+  const { month } = await searchParams;
+  const activeMonth = resolveMonth(month);
+
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { data: workspace } = await supabase
+    .from("workspaces")
+    .select("id, name, slug")
+    .eq("slug", workspaceSlug)
+    .single();
+
+  if (!workspace) {
+    notFound();
+  }
+
+  const { data: membership } = await supabase
+    .from("workspace_members")
+    .select("workspace_id")
+    .eq("workspace_id", workspace.id)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!membership) {
+    redirect("/");
+  }
+
+  const monthStart = activeMonth.toISOString().slice(0, 10);
+  const monthEndDate = new Date(Date.UTC(activeMonth.getUTCFullYear(), activeMonth.getUTCMonth() + 1, 0));
+  const monthEnd = monthEndDate.toISOString().slice(0, 10);
+
+  const { data: projects } = await supabase
+    .from("projects")
+    .select("id, name")
+    .eq("workspace_id", workspace.id)
+    .order("created_at", { ascending: true });
+
+  const { data: tasks } = await supabase
+    .from("blocks")
+    .select("id, properties")
+    .eq("workspace_id", workspace.id)
+    .eq("type", "task")
+    .gte("properties->>due_date", monthStart)
+    .lte("properties->>due_date", monthEnd)
+    .order("properties->>due_date", { ascending: true });
+
+  const calendarEvents: CalendarTaskEvent[] = ((tasks ?? []) as TaskBlockRow[])
+    .filter((task) => typeof task.properties?.due_date === "string")
+    .map((task) => ({
+      id: task.id,
+      title: task.properties?.title?.trim() || "Bez tytułu",
+      dueDate: task.properties.due_date as string,
+      priority: task.properties?.priority,
+      status: task.properties?.status,
+    }));
+
+  return (
+    <div className="px-8 py-6">
+      <CalendarPageClient
+        workspaceSlug={workspaceSlug}
+        workspaceId={workspace.id}
+        workspaceName={workspace.name}
+        activeMonth={formatMonthKey(activeMonth)}
+        events={calendarEvents}
+        projects={(projects ?? []) as CalendarWorkspaceProject[]}
+      />
+    </div>
+  );
+}

--- a/src/app/api/blocks/route.ts
+++ b/src/app/api/blocks/route.ts
@@ -8,6 +8,8 @@ interface CreateBlockPayload {
   type?: string;
   title?: string;
   status?: TaskStatus;
+  dueDate?: string;
+  priority?: "low" | "medium" | "high" | "urgent";
 }
 
 function isTaskStatus(value?: string): value is TaskStatus {
@@ -16,6 +18,14 @@ function isTaskStatus(value?: string): value is TaskStatus {
   }
 
   return TASK_STATUSES.includes(value as TaskStatus);
+}
+
+function isDueDate(value?: string): boolean {
+  if (!value) {
+    return true;
+  }
+
+  return /^\d{4}-\d{2}-\d{2}$/.test(value);
 }
 
 export async function POST(request: Request) {
@@ -46,6 +56,10 @@ export async function POST(request: Request) {
 
   if (!isTaskStatus(body.status)) {
     return NextResponse.json({ data: null, error: "Nieprawidłowy status zadania." }, { status: 400 });
+  }
+
+  if (!isDueDate(body.dueDate)) {
+    return NextResponse.json({ data: null, error: "Nieprawidłowy format due date (YYYY-MM-DD)." }, { status: 400 });
   }
 
   const { data: membership, error: membershipError } = await supabase
@@ -82,6 +96,8 @@ export async function POST(request: Request) {
       properties: {
         title: body.title.trim(),
         status: body.status,
+        due_date: body.dueDate,
+        priority: body.priority,
       },
     })
     .select("id, properties, position")

--- a/src/components/calendar/CalendarPageClient.tsx
+++ b/src/components/calendar/CalendarPageClient.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import { useMemo, useState, type FormEvent } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+export interface CalendarTaskEvent {
+  id: string;
+  title: string;
+  dueDate: string;
+  priority?: "low" | "medium" | "high" | "urgent";
+  status?: "todo" | "in_progress" | "done";
+}
+
+export interface CalendarWorkspaceProject {
+  id: string;
+  name: string;
+}
+
+interface CalendarPageClientProps {
+  workspaceSlug: string;
+  workspaceId: string;
+  workspaceName: string;
+  activeMonth: string;
+  events: CalendarTaskEvent[];
+  projects: CalendarWorkspaceProject[];
+}
+
+interface CalendarDayCell {
+  isoDate: string;
+  dayOfMonth: number;
+  isCurrentMonth: boolean;
+}
+
+const WEEKDAY_LABELS = ["Pon", "Wt", "Śr", "Czw", "Pt", "Sob", "Ndz"];
+
+const PRIORITY_BADGES: Record<NonNullable<CalendarTaskEvent["priority"]>, string> = {
+  low: "bg-emerald-500/20 text-emerald-300",
+  medium: "bg-sky-500/20 text-sky-300",
+  high: "bg-amber-500/20 text-amber-300",
+  urgent: "bg-rose-500/20 text-rose-300",
+};
+
+const STATUS_BADGES: Record<NonNullable<CalendarTaskEvent["status"]>, string> = {
+  todo: "bg-slate-500/20 text-slate-300",
+  in_progress: "bg-indigo-500/20 text-indigo-300",
+  done: "bg-emerald-500/20 text-emerald-300",
+};
+
+function parseMonthKey(monthKey: string): Date {
+  const [yearString, monthString] = monthKey.split("-");
+  const year = Number(yearString);
+  const monthIndex = Number(monthString) - 1;
+
+  return new Date(Date.UTC(year, monthIndex, 1));
+}
+
+function formatMonthKey(date: Date): string {
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function shiftMonth(monthKey: string, delta: number): string {
+  const monthDate = parseMonthKey(monthKey);
+  return formatMonthKey(new Date(Date.UTC(monthDate.getUTCFullYear(), monthDate.getUTCMonth() + delta, 1)));
+}
+
+function buildMonthGrid(monthKey: string): CalendarDayCell[] {
+  const monthDate = parseMonthKey(monthKey);
+  const firstDay = new Date(Date.UTC(monthDate.getUTCFullYear(), monthDate.getUTCMonth(), 1));
+  const jsDay = firstDay.getUTCDay();
+  const mondayOffset = (jsDay + 6) % 7;
+  const gridStart = new Date(Date.UTC(monthDate.getUTCFullYear(), monthDate.getUTCMonth(), 1 - mondayOffset));
+
+  const lastDay = new Date(Date.UTC(monthDate.getUTCFullYear(), monthDate.getUTCMonth() + 1, 0));
+  const trailingCount = (7 - (((lastDay.getUTCDay() + 6) % 7) + 1)) % 7;
+  const totalDays = mondayOffset + lastDay.getUTCDate() + trailingCount;
+  const cellCount = totalDays > 35 ? 42 : 35;
+
+  return Array.from({ length: cellCount }, (_, index) => {
+    const date = new Date(Date.UTC(gridStart.getUTCFullYear(), gridStart.getUTCMonth(), gridStart.getUTCDate() + index));
+    const isoDate = date.toISOString().slice(0, 10);
+
+    return {
+      isoDate,
+      dayOfMonth: date.getUTCDate(),
+      isCurrentMonth: date.getUTCMonth() === monthDate.getUTCMonth(),
+    };
+  });
+}
+
+function CalendarEvent({ workspaceSlug, event }: { workspaceSlug: string; event: CalendarTaskEvent }) {
+  const accentClass = event.priority ? PRIORITY_BADGES[event.priority] : event.status ? STATUS_BADGES[event.status] : "bg-bg-elevated text-content-secondary";
+
+  return (
+    <Link
+      href={`/${workspaceSlug}/block/${event.id}`}
+      className={cn(
+        "block truncate rounded-md px-2 py-1 text-xs transition hover:brightness-110",
+        accentClass
+      )}
+      title={event.title}
+      onClick={(eventClick) => eventClick.stopPropagation()}
+    >
+      {event.title}
+    </Link>
+  );
+}
+
+function CreateTaskModal({
+  workspaceId,
+  dueDate,
+  projects,
+  onClose,
+  onCreated,
+}: {
+  workspaceId: string;
+  dueDate: string;
+  projects: CalendarWorkspaceProject[];
+  onClose: () => void;
+  onCreated: () => void;
+}) {
+  const [title, setTitle] = useState("");
+  const [status, setStatus] = useState<"todo" | "in_progress" | "done">("todo");
+  const [priority, setPriority] = useState<"low" | "medium" | "high" | "urgent">("medium");
+  const [projectId, setProjectId] = useState(projects[0]?.id ?? "");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!title.trim()) {
+      setError("Tytuł zadania jest wymagany.");
+      return;
+    }
+
+    if (!projectId) {
+      setError("Wybierz projekt dla zadania.");
+      return;
+    }
+
+    setError(null);
+    setIsSubmitting(true);
+
+    const response = await fetch("/api/blocks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        workspaceId,
+        projectId,
+        type: "task",
+        title: title.trim(),
+        status,
+        dueDate,
+        priority,
+      }),
+    });
+
+    setIsSubmitting(false);
+
+    if (!response.ok) {
+      const payload = (await response.json()) as { error?: string };
+      setError(payload.error ?? "Nie udało się utworzyć zadania.");
+      return;
+    }
+
+    onCreated();
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+      <div className="w-full max-w-md rounded-lg border border-border-subtle bg-bg-surface p-5 shadow-2xl">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-content-primary">Nowe zadanie ({dueDate})</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1 text-content-muted transition hover:bg-bg-elevated hover:text-content-primary"
+            aria-label="Zamknij modal"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="calendar-task-title">Tytuł</Label>
+            <Input
+              id="calendar-task-title"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder="Np. Przygotuj demo"
+              maxLength={120}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="calendar-task-project">Projekt</Label>
+            <select
+              id="calendar-task-project"
+              value={projectId}
+              onChange={(event) => setProjectId(event.target.value)}
+              className="h-9 w-full rounded-md border border-border-subtle bg-bg-subtle px-3 text-sm text-content-primary"
+            >
+              {projects.map((project) => (
+                <option key={project.id} value={project.id}>
+                  {project.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="calendar-task-status">Status</Label>
+              <select
+                id="calendar-task-status"
+                value={status}
+                onChange={(event) => setStatus(event.target.value as "todo" | "in_progress" | "done")}
+                className="h-9 w-full rounded-md border border-border-subtle bg-bg-subtle px-3 text-sm text-content-primary"
+              >
+                <option value="todo">Todo</option>
+                <option value="in_progress">In Progress</option>
+                <option value="done">Done</option>
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="calendar-task-priority">Priorytet</Label>
+              <select
+                id="calendar-task-priority"
+                value={priority}
+                onChange={(event) => setPriority(event.target.value as "low" | "medium" | "high" | "urgent")}
+                className="h-9 w-full rounded-md border border-border-subtle bg-bg-subtle px-3 text-sm text-content-primary"
+              >
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+                <option value="urgent">Urgent</option>
+              </select>
+            </div>
+          </div>
+
+          {error && <p className="text-sm text-red-400">{error}</p>}
+
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
+              Anuluj
+            </Button>
+            <Button type="submit" disabled={isSubmitting || !projects.length}>
+              {isSubmitting ? "Tworzenie..." : "Utwórz zadanie"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export function CalendarPageClient({ workspaceSlug, workspaceId, workspaceName, activeMonth, events, projects }: CalendarPageClientProps) {
+  const router = useRouter();
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+
+  const monthDate = parseMonthKey(activeMonth);
+  const monthLabel = new Intl.DateTimeFormat("pl-PL", { month: "long", year: "numeric", timeZone: "UTC" }).format(monthDate);
+  const days = useMemo(() => buildMonthGrid(activeMonth), [activeMonth]);
+  const eventsByDay = useMemo(() => {
+    const grouped = new Map<string, CalendarTaskEvent[]>();
+
+    for (const event of events) {
+      const list = grouped.get(event.dueDate) ?? [];
+      list.push(event);
+      grouped.set(event.dueDate, list);
+    }
+
+    return grouped;
+  }, [events]);
+
+  return (
+    <>
+      <div className="mb-6 flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold text-content-primary">Kalendarz — {workspaceName}</h1>
+          <p className="text-sm text-content-muted">Miesięczny widok zadań z due date.</p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button variant="outline" asChild>
+            <Link href={`/${workspaceSlug}/calendar?month=${shiftMonth(activeMonth, -1)}`} aria-label="Poprzedni miesiąc">
+              <ChevronLeft className="h-4 w-4" />
+            </Link>
+          </Button>
+          <span className="min-w-44 text-center text-sm font-medium capitalize text-content-primary">{monthLabel}</span>
+          <Button variant="outline" asChild>
+            <Link href={`/${workspaceSlug}/calendar?month=${shiftMonth(activeMonth, 1)}`} aria-label="Następny miesiąc">
+              <ChevronRight className="h-4 w-4" />
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-border-subtle bg-bg-surface">
+        <div className="grid grid-cols-7 border-b border-border-subtle bg-bg-subtle">
+          {WEEKDAY_LABELS.map((weekday) => (
+            <div key={weekday} className="px-3 py-2 text-xs font-semibold uppercase tracking-wide text-content-muted">
+              {weekday}
+            </div>
+          ))}
+        </div>
+
+        <div className="grid grid-cols-7">
+          {days.map((day) => (
+            <div
+              key={day.isoDate}
+              role="button"
+              tabIndex={0}
+              onClick={() => setSelectedDate(day.isoDate)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  setSelectedDate(day.isoDate);
+                }
+              }}
+              className={cn(
+                "min-h-32 border-b border-r border-border-subtle p-2 text-left align-top transition hover:bg-bg-elevated",
+                !day.isCurrentMonth && "bg-bg-subtle/40 text-content-muted"
+              )}
+            >
+              <div className="mb-2 text-sm font-medium">{day.dayOfMonth}</div>
+              <div className="space-y-1">
+                {(eventsByDay.get(day.isoDate) ?? []).slice(0, 3).map((event) => (
+                  <CalendarEvent key={event.id} workspaceSlug={workspaceSlug} event={event} />
+                ))}
+                {(eventsByDay.get(day.isoDate)?.length ?? 0) > 3 && (
+                  <p className="px-1 text-xs text-content-muted">+{(eventsByDay.get(day.isoDate)?.length ?? 0) - 3} więcej</p>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {selectedDate && (
+        <CreateTaskModal
+          workspaceId={workspaceId}
+          dueDate={selectedDate}
+          projects={projects}
+          onClose={() => setSelectedDate(null)}
+          onCreated={() => {
+            setSelectedDate(null);
+            router.refresh();
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import { type ComponentType, type FormEvent, useMemo, useState, useTransition } 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import {
+  CalendarDays,
   Check,
   ChevronLeft,
   ChevronRight,
@@ -340,6 +341,13 @@ export function Sidebar({ currentWorkspaceSlug, workspaceId, workspaces, project
           label="Notatki"
           icon={NotebookPen}
           isActive={pathname.includes("/notes")}
+          collapsed={isCollapsed}
+        />
+        <SidebarLink
+          href={`/${currentWorkspaceSlug}/calendar`}
+          label="Kalendarz"
+          icon={CalendarDays}
+          isActive={pathname.includes("/calendar")}
           collapsed={isCollapsed}
         />
         <SidebarLink


### PR DESCRIPTION
### Motivation
- Umożliwić przegląd zadań posiadających `due_date` w formie miesięcznej siatki oraz szybkie tworzenie z prefilled datą.
- Zapewnić prostą nawigację między miesiącami i linkowanie do szczegółów zadania (`/block/[blockId]`).

### Description
- Dodano serwerową stronę RSC `/[workspaceSlug]/calendar` która pobiera zadania `type='task'` z `due_date` mieszczącym się w wybranym miesiącu i listę projektów oraz przekazuje je do klienta (`src/app/(dashboard)/[workspaceSlug]/calendar/page.tsx`).
- Wprowadzono komponent klienta `CalendarPageClient` (`src/components/calendar/CalendarPageClient.tsx`) implementujący siatkę miesięczną 7×5/6, nawigację miesiącową, grupowanie eventów po dniu, kolorowanie wg `priority` (fallback `status`) oraz kliknięcie dnia otwierające modal tworzenia zadania z prefilled `due_date`.
- Dodano modal tworzenia zadania z kalendarza wysyłający `dueDate` i `priority` do API oraz odświeżający widok po utworzeniu (linkowanie do projektów i walidacja pól po stronie klienta).
- Rozszerzono endpoint tworzenia bloków (`src/app/api/blocks/route.ts`) o pola `dueDate` i `priority` oraz dodano walidację formatu daty (`YYYY-MM-DD`).
- Dodano wpis „Kalendarz” w sidebarze, aby widok był dostępny z nawigacji workspace (`src/components/layout/Sidebar.tsx`).

### Testing
- `npm run build` zakończył się pomyślnie i aplikacja wygenerowała nowe trasy, w tym `/{workspaceSlug}/calendar` (sukces). 
- `npm run lint` nie uruchomił się w tym środowisku z powodu braku modułu `eslint-config-next/core-web-vitals`, co powoduje błąd rozwiązywania zależności (środowiskowy). 
- Uruchomiono serwer deweloperski (`npm run dev`) i wykonano automatyczny zrzut ekranu widoku kalendarza przez Playwright w trybie headless jako szybką weryfikację wizualną (screenshot wygenerowany pomyślnie).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a06491f0f483308e89b617e5e26c50)