### PR TITLE
Add notes page tree in sidebar with page creation and drag & drop

### DIFF
--- a/src/app/(dashboard)/[workspaceSlug]/layout.tsx
+++ b/src/app/(dashboard)/[workspaceSlug]/layout.tsx
@@ -25,6 +25,15 @@ interface WorkspaceMembership {
   } | null;
 }
 
+interface PageItem {
+  id: string;
+  parent_block_id: string | null;
+  position: number;
+  properties: {
+    title?: string;
+  } | null;
+}
+
 async function DashboardShell({ children, workspaceSlug }: DashboardShellProps) {
   const supabase = await createServerClient();
 
@@ -67,6 +76,14 @@ async function DashboardShell({ children, workspaceSlug }: DashboardShellProps) 
     .eq("workspace_id", currentWorkspace.id)
     .order("created_at", { ascending: true });
 
+  const { data: pages } = await supabase
+    .from("blocks")
+    .select("id, parent_block_id, position, properties")
+    .eq("workspace_id", currentWorkspace.id)
+    .eq("type", "page")
+    .order("position", { ascending: true })
+    .returns<PageItem[]>();
+
   return (
     <ReactQueryProvider>
       <Sidebar
@@ -74,6 +91,7 @@ async function DashboardShell({ children, workspaceSlug }: DashboardShellProps) 
         workspaceId={currentWorkspace.id}
         workspaces={workspaces}
         projects={projects ?? []}
+        pages={pages ?? []}
       />
       <div className="flex min-w-0 flex-1 flex-col">
         <Navbar workspaceName={currentWorkspace.name} userEmail={user.email ?? user.id} />

--- a/src/app/(dashboard)/[workspaceSlug]/notes/page.tsx
+++ b/src/app/(dashboard)/[workspaceSlug]/notes/page.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { createServerClient } from "@/lib/supabase/server";
+
+interface NotesPageProps {
+  params: Promise<{ workspaceSlug: string }>;
+}
+
+interface WorkspaceRecord {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+interface RecentPage {
+  id: string;
+  updated_at: string;
+  properties: { title?: string } | null;
+}
+
+export default async function NotesPage({ params }: NotesPageProps) {
+  const { workspaceSlug } = await params;
+  const supabase = await createServerClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { data: workspace } = await supabase
+    .from("workspaces")
+    .select("id, name, slug")
+    .eq("slug", workspaceSlug)
+    .single<WorkspaceRecord>();
+
+  if (!workspace) {
+    notFound();
+  }
+
+  const { data: membership } = await supabase
+    .from("workspace_members")
+    .select("workspace_id")
+    .eq("workspace_id", workspace.id)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!membership) {
+    redirect("/");
+  }
+
+  const { data: recentPages } = await supabase
+    .from("blocks")
+    .select("id, updated_at, properties")
+    .eq("workspace_id", workspace.id)
+    .eq("type", "page")
+    .order("updated_at", { ascending: false })
+    .limit(12)
+    .returns<RecentPage[]>();
+
+  return (
+    <div className="mx-auto w-full max-w-4xl px-6 py-8">
+      <h1 className="text-2xl font-semibold text-content-primary">Notatki — {workspace.name}</h1>
+      <p className="mt-2 text-sm text-content-muted">Ostatnio edytowane strony</p>
+
+      <div className="mt-6 rounded-lg border border-border-subtle bg-bg-surface">
+        {(recentPages ?? []).length ? (
+          <ul className="divide-y divide-border-subtle">
+            {(recentPages ?? []).map((page) => (
+              <li key={page.id}>
+                <Link
+                  href={`/${workspaceSlug}/block/${page.id}`}
+                  className="flex items-center justify-between px-4 py-3 text-sm transition hover:bg-bg-elevated"
+                >
+                  <span className="truncate text-content-primary">{page.properties?.title?.trim() || "Bez tytułu"}</span>
+                  <span className="ml-4 shrink-0 text-xs text-content-muted">
+                    {new Date(page.updated_at).toLocaleString("pl-PL")}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="px-4 py-6 text-sm text-content-muted">Brak stron. Utwórz pierwszą stronę w sidebarze.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/blocks/route.ts
+++ b/src/app/api/blocks/route.ts
@@ -5,6 +5,7 @@ import { createServerClient } from "@/lib/supabase/server";
 interface CreateBlockPayload {
   workspaceId?: string;
   projectId?: string;
+  parentBlockId?: string | null;
   type?: string;
   title?: string;
   status?: TaskStatus;
@@ -42,24 +43,12 @@ export async function POST(request: Request) {
 
   const body = (await request.json()) as CreateBlockPayload;
 
-  if (body.type !== "task") {
-    return NextResponse.json({ data: null, error: "Dozwolone jest tworzenie wyłącznie bloków task." }, { status: 400 });
-  }
-
-  if (!body.workspaceId || !body.projectId) {
-    return NextResponse.json({ data: null, error: "workspaceId i projectId są wymagane." }, { status: 400 });
+  if (!body.workspaceId) {
+    return NextResponse.json({ data: null, error: "workspaceId jest wymagane." }, { status: 400 });
   }
 
   if (!body.title?.trim()) {
     return NextResponse.json({ data: null, error: "Tytuł jest wymagany." }, { status: 400 });
-  }
-
-  if (!isTaskStatus(body.status)) {
-    return NextResponse.json({ data: null, error: "Nieprawidłowy status zadania." }, { status: 400 });
-  }
-
-  if (!isDueDate(body.dueDate)) {
-    return NextResponse.json({ data: null, error: "Nieprawidłowy format due date (YYYY-MM-DD)." }, { status: 400 });
   }
 
   const { data: membership, error: membershipError } = await supabase
@@ -73,39 +62,91 @@ export async function POST(request: Request) {
     return NextResponse.json({ data: null, error: "Brak dostępu do workspace." }, { status: 403 });
   }
 
-  const { data: lastTask } = await supabase
-    .from("blocks")
-    .select("position")
-    .eq("workspace_id", body.workspaceId)
-    .eq("project_id", body.projectId)
-    .eq("type", "task")
-    .order("position", { ascending: false })
-    .limit(1)
-    .maybeSingle();
+  if (body.type === "task") {
+    if (!body.projectId) {
+      return NextResponse.json({ data: null, error: "projectId jest wymagane dla task." }, { status: 400 });
+    }
 
-  const nextPosition = (lastTask?.position ?? 0) + 1;
+    if (!isTaskStatus(body.status)) {
+      return NextResponse.json({ data: null, error: "Nieprawidłowy status zadania." }, { status: 400 });
+    }
 
-  const { data, error } = await supabase
-    .from("blocks")
-    .insert({
-      workspace_id: body.workspaceId,
-      project_id: body.projectId,
-      type: "task",
-      created_by: user.id,
-      position: nextPosition,
-      properties: {
-        title: body.title.trim(),
-        status: body.status,
-        due_date: body.dueDate,
-        priority: body.priority,
-      },
-    })
-    .select("id, properties, position")
-    .single();
+    if (!isDueDate(body.dueDate)) {
+      return NextResponse.json({ data: null, error: "Nieprawidłowy format due date (YYYY-MM-DD)." }, { status: 400 });
+    }
 
-  if (error || !data) {
-    return NextResponse.json({ data: null, error: error?.message ?? "Nie udało się utworzyć zadania." }, { status: 500 });
+    const { data: lastTask } = await supabase
+      .from("blocks")
+      .select("position")
+      .eq("workspace_id", body.workspaceId)
+      .eq("project_id", body.projectId)
+      .eq("type", "task")
+      .order("position", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const nextPosition = (lastTask?.position ?? 0) + 1;
+
+    const { data, error } = await supabase
+      .from("blocks")
+      .insert({
+        workspace_id: body.workspaceId,
+        project_id: body.projectId,
+        type: "task",
+        created_by: user.id,
+        position: nextPosition,
+        properties: {
+          title: body.title.trim(),
+          status: body.status,
+          due_date: body.dueDate,
+          priority: body.priority,
+        },
+      })
+      .select("id, properties, position")
+      .single();
+
+    if (error || !data) {
+      return NextResponse.json({ data: null, error: error?.message ?? "Nie udało się utworzyć zadania." }, { status: 500 });
+    }
+
+    return NextResponse.json({ data, error: null }, { status: 201 });
   }
 
-  return NextResponse.json({ data, error: null }, { status: 201 });
+  if (body.type === "page") {
+    const { data: lastPage } = await supabase
+      .from("blocks")
+      .select("position")
+      .eq("workspace_id", body.workspaceId)
+      .eq("type", "page")
+      .is("parent_block_id", body.parentBlockId ?? null)
+      .order("position", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const nextPosition = (lastPage?.position ?? 0) + 1;
+
+    const { data, error } = await supabase
+      .from("blocks")
+      .insert({
+        workspace_id: body.workspaceId,
+        type: "page",
+        created_by: user.id,
+        parent_block_id: body.parentBlockId ?? null,
+        position: nextPosition,
+        properties: {
+          title: body.title.trim(),
+        },
+        content: [],
+      })
+      .select("id, parent_block_id, position, properties")
+      .single();
+
+    if (error || !data) {
+      return NextResponse.json({ data: null, error: error?.message ?? "Nie udało się utworzyć strony." }, { status: 500 });
+    }
+
+    return NextResponse.json({ data, error: null }, { status: 201 });
+  }
+
+  return NextResponse.json({ data: null, error: "Dozwolone typy bloków: task i page." }, { status: 400 });
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -19,6 +19,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useSidebarStore } from "@/lib/stores/sidebar-store";
 import { WorkspaceSwitcher } from "@/components/layout/WorkspaceSwitcher";
+import { NotesTreeSidebar } from "@/components/notes/NotesTreeSidebar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -42,6 +43,7 @@ interface SidebarProps {
   workspaceId: string;
   workspaces: WorkspaceItem[];
   projects: ProjectItem[];
+  pages: Array<{ id: string; parent_block_id: string | null; position: number; properties: { title?: string } | null }>;
 }
 
 interface SidebarLinkProps {
@@ -191,7 +193,7 @@ export function SidebarSkeleton() {
   );
 }
 
-export function Sidebar({ currentWorkspaceSlug, workspaceId, workspaces, projects }: SidebarProps) {
+export function Sidebar({ currentWorkspaceSlug, workspaceId, workspaces, projects, pages }: SidebarProps) {
   const pathname = usePathname();
   const router = useRouter();
   const { isCollapsed, toggle } = useSidebarStore();
@@ -360,6 +362,12 @@ export function Sidebar({ currentWorkspaceSlug, workspaceId, workspaces, project
       </nav>
 
       <div className="mt-6 flex-1 overflow-y-auto">
+        <NotesTreeSidebar
+          workspaceId={workspaceId}
+          workspaceSlug={currentWorkspaceSlug}
+          isCollapsed={isCollapsed}
+          pages={pages}
+        />
         {!isCollapsed && (
           <div className="mb-2 flex items-center justify-between px-1">
             <p className="text-xs uppercase tracking-wider text-content-muted">Projekty</p>

--- a/src/components/notes/NotesTreeSidebar.tsx
+++ b/src/components/notes/NotesTreeSidebar.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { Plus } from "lucide-react";
+import { type SidebarPageItem, PageTreeItem } from "@/components/notes/PageTreeItem";
+import { Button } from "@/components/ui/button";
+
+interface NotesTreeSidebarProps {
+  workspaceId: string;
+  workspaceSlug: string;
+  isCollapsed: boolean;
+  pages: Array<{ id: string; parent_block_id: string | null; position: number; properties: { title?: string } | null }>;
+}
+
+export function NotesTreeSidebar({ workspaceId, workspaceSlug, isCollapsed, pages }: NotesTreeSidebarProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [draggedPageId, setDraggedPageId] = useState<string | null>(null);
+  const [expandedPageIds, setExpandedPageIds] = useState<Set<string>>(new Set());
+  const [pageItems, setPageItems] = useState<SidebarPageItem[]>(
+    pages.map((page) => ({
+      id: page.id,
+      parentBlockId: page.parent_block_id,
+      position: page.position,
+      title: page.properties?.title?.trim() || "Bez tytułu",
+    }))
+  );
+
+  const pageMap = useMemo(() => new Map(pageItems.map((page) => [page.id, page])), [pageItems]);
+  const pagesByParent = useMemo(() => {
+    const grouped = new Map<string | null, SidebarPageItem[]>();
+    for (const page of pageItems) {
+      const items = grouped.get(page.parentBlockId) ?? [];
+      items.push(page);
+      grouped.set(page.parentBlockId, items);
+    }
+    for (const [, items] of grouped) {
+      items.sort((a, b) => a.position - b.position);
+    }
+    return grouped;
+  }, [pageItems]);
+
+  function normalizePositions(items: SidebarPageItem[]) {
+    const grouped = new Map<string | null, SidebarPageItem[]>();
+    for (const item of items) {
+      const siblings = grouped.get(item.parentBlockId) ?? [];
+      siblings.push(item);
+      grouped.set(item.parentBlockId, siblings);
+    }
+
+    const updates = new Map<string, number>();
+    for (const [, siblings] of grouped) {
+      siblings.sort((a, b) => a.position - b.position).forEach((sibling, index) => updates.set(sibling.id, index + 1));
+    }
+
+    return items.map((item) => ({ ...item, position: updates.get(item.id) ?? item.position }));
+  }
+
+  function updatePageTree(movingId: string, parentBlockId: string | null, insertionIndex: number): SidebarPageItem[] {
+    const movingPage = pageMap.get(movingId);
+    if (!movingPage) return pageItems;
+
+    const withoutMoving = pageItems.filter((page) => page.id !== movingId);
+    const siblings = withoutMoving.filter((page) => page.parentBlockId === parentBlockId).sort((a, b) => a.position - b.position);
+    const clampedIndex = Math.max(0, Math.min(insertionIndex, siblings.length));
+
+    const previous = siblings[clampedIndex - 1];
+    const next = siblings[clampedIndex];
+
+    let nextPosition = 1;
+    if (previous && next) nextPosition = (previous.position + next.position) / 2;
+    else if (previous) nextPosition = previous.position + 1;
+    else if (next) nextPosition = Math.max(next.position / 2, 0.1);
+
+    return normalizePositions([...withoutMoving, { ...movingPage, parentBlockId, position: nextPosition }]);
+  }
+
+  function isDescendant(candidateId: string, ancestorId: string): boolean {
+    let current: string | null = pageMap.get(candidateId)?.parentBlockId ?? null;
+    while (current) {
+      if (current === ancestorId) return true;
+      current = pageMap.get(current)?.parentBlockId ?? null;
+    }
+    return false;
+  }
+
+  function persistPageMove(pageId: string, parentBlockId: string | null, position: number) {
+    startTransition(async () => {
+      const response = await fetch(`/api/blocks/${pageId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ parent_block_id: parentBlockId, position }),
+      });
+
+      if (!response.ok) router.refresh();
+    });
+  }
+
+  function handleCreatePage(parentBlockId: string | null = null) {
+    const tempId = `temp-page-${crypto.randomUUID()}`;
+    const maxPosition = pageItems
+      .filter((page) => page.parentBlockId === parentBlockId)
+      .reduce((max, page) => Math.max(max, page.position), 0);
+
+    setPageItems((current) => [...current, { id: tempId, title: "Nowa strona", parentBlockId, position: maxPosition + 1 }]);
+    if (parentBlockId) setExpandedPageIds((current) => new Set(current).add(parentBlockId));
+
+    startTransition(async () => {
+      const response = await fetch("/api/blocks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ workspaceId, type: "page", title: "Nowa strona", parentBlockId }),
+      });
+
+      if (!response.ok) {
+        setPageItems((current) => current.filter((page) => page.id !== tempId));
+        return;
+      }
+
+      const payload = (await response.json()) as {
+        data?: { id: string; parent_block_id: string | null; position: number; properties?: { title?: string } };
+      };
+
+      if (!payload.data) {
+        setPageItems((current) => current.filter((page) => page.id !== tempId));
+        return;
+      }
+
+      setPageItems((current) =>
+        current.map((page) =>
+          page.id === tempId
+            ? {
+                id: payload.data!.id,
+                parentBlockId: payload.data!.parent_block_id,
+                position: payload.data!.position,
+                title: payload.data!.properties?.title?.trim() || "Nowa strona",
+              }
+            : page
+        )
+      );
+
+      router.push(`/${workspaceSlug}/block/${payload.data.id}`);
+      router.refresh();
+    });
+  }
+
+  function handleDropIntoPage(targetPageId: string) {
+    if (!draggedPageId || draggedPageId === targetPageId || isDescendant(targetPageId, draggedPageId)) {
+      setDraggedPageId(null);
+      return;
+    }
+
+    const siblingCount = pageItems.filter((page) => page.parentBlockId === targetPageId).length;
+    const nextPages = updatePageTree(draggedPageId, targetPageId, siblingCount);
+    const movedPage = nextPages.find((page) => page.id === draggedPageId);
+    if (!movedPage) return;
+
+    setPageItems(nextPages);
+    setExpandedPageIds((current) => new Set(current).add(targetPageId));
+    persistPageMove(movedPage.id, movedPage.parentBlockId, movedPage.position);
+    setDraggedPageId(null);
+  }
+
+  function handleDropBetween(parentBlockId: string | null, insertionIndex: number) {
+    if (!draggedPageId) return;
+    if (parentBlockId && (draggedPageId === parentBlockId || isDescendant(parentBlockId, draggedPageId))) {
+      setDraggedPageId(null);
+      return;
+    }
+
+    const nextPages = updatePageTree(draggedPageId, parentBlockId, insertionIndex);
+    const movedPage = nextPages.find((page) => page.id === draggedPageId);
+    if (!movedPage) return;
+
+    setPageItems(nextPages);
+    persistPageMove(movedPage.id, movedPage.parentBlockId, movedPage.position);
+    setDraggedPageId(null);
+  }
+
+  function toggleExpanded(pageId: string) {
+    setExpandedPageIds((current) => {
+      const next = new Set(current);
+      if (next.has(pageId)) next.delete(pageId);
+      else next.add(pageId);
+      return next;
+    });
+  }
+
+  function renderPageTree(parentBlockId: string | null, depth = 0): React.ReactNode {
+    const items = pagesByParent.get(parentBlockId) ?? [];
+
+    return (
+      <>
+        <div
+          className="h-1 rounded bg-transparent transition hover:bg-sky-500/20"
+          onDragOver={(event) => event.preventDefault()}
+          onDrop={(event) => {
+            event.preventDefault();
+            handleDropBetween(parentBlockId, 0);
+          }}
+        />
+        {items.map((page, index) => {
+          const children = pagesByParent.get(page.id) ?? [];
+          const isExpanded = expandedPageIds.has(page.id);
+
+          return (
+            <div key={page.id}>
+              <PageTreeItem
+                page={page}
+                workspaceSlug={workspaceSlug}
+                depth={depth}
+                isCollapsed={isCollapsed}
+                isExpanded={isExpanded}
+                hasChildren={children.length > 0}
+                isActive={pathname.startsWith(`/${workspaceSlug}/block/${page.id}`)}
+                onToggle={toggleExpanded}
+                onCreateChild={handleCreatePage}
+                onDragStart={setDraggedPageId}
+                onDropInside={handleDropIntoPage}
+              />
+
+              {!isCollapsed && children.length > 0 && isExpanded && <div>{renderPageTree(page.id, depth + 1)}</div>}
+
+              <div
+                className="h-1 rounded bg-transparent transition hover:bg-sky-500/20"
+                onDragOver={(event) => event.preventDefault()}
+                onDrop={(event) => {
+                  event.preventDefault();
+                  handleDropBetween(parentBlockId, index + 1);
+                }}
+              />
+            </div>
+          );
+        })}
+      </>
+    );
+  }
+
+  if (isCollapsed) {
+    return (
+      <Button type="button" variant="ghost" size="icon" className="mb-2 h-8 w-8" onClick={() => handleCreatePage(null)} title="Nowa strona">
+        <Plus className="h-4 w-4" />
+      </Button>
+    );
+  }
+
+  return (
+    <div className="mb-3 space-y-2 border-b border-border-subtle pb-3">
+      <div className="flex items-center justify-between px-1">
+        <p className="text-xs uppercase tracking-wider text-content-muted">Strony</p>
+        <Button type="button" variant="ghost" size="sm" className="h-7 px-2" onClick={() => handleCreatePage(null)}>
+          <Plus className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <div className="space-y-0.5">{renderPageTree(null)}</div>
+      {isPending && <p className="px-2 text-xs text-content-muted">Aktualizacja drzewa...</p>}
+    </div>
+  );
+}

--- a/src/components/notes/PageTreeItem.tsx
+++ b/src/components/notes/PageTreeItem.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import Link from "next/link";
+import { ChevronDown, ChevronRight, FileText, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface SidebarPageItem {
+  id: string;
+  title: string;
+  parentBlockId: string | null;
+  position: number;
+}
+
+interface PageTreeItemProps {
+  page: SidebarPageItem;
+  workspaceSlug: string;
+  depth: number;
+  isCollapsed: boolean;
+  isExpanded: boolean;
+  hasChildren: boolean;
+  isActive: boolean;
+  onToggle: (pageId: string) => void;
+  onCreateChild: (parentId: string) => void;
+  onDragStart: (pageId: string) => void;
+  onDropInside: (targetId: string) => void;
+}
+
+export function PageTreeItem({
+  page,
+  workspaceSlug,
+  depth,
+  isCollapsed,
+  isExpanded,
+  hasChildren,
+  isActive,
+  onToggle,
+  onCreateChild,
+  onDragStart,
+  onDropInside,
+}: PageTreeItemProps) {
+  return (
+    <div
+      className="group"
+      draggable
+      onDragStart={() => onDragStart(page.id)}
+      onDragOver={(event) => event.preventDefault()}
+      onDrop={(event) => {
+        event.preventDefault();
+        onDropInside(page.id);
+      }}
+    >
+      <div className="flex items-center gap-1">
+        {!isCollapsed ? (
+          <button
+            type="button"
+            className="rounded p-0.5 text-content-muted hover:bg-bg-elevated hover:text-content-primary"
+            onClick={() => hasChildren && onToggle(page.id)}
+            aria-label={isExpanded ? "Zwiń podstrony" : "Rozwiń podstrony"}
+          >
+            {hasChildren ? (
+              isExpanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />
+            ) : (
+              <span className="block h-3.5 w-3.5" />
+            )}
+          </button>
+        ) : null}
+
+        <Link
+          href={`/${workspaceSlug}/block/${page.id}`}
+          className={cn(
+            "flex h-8 min-w-0 flex-1 items-center rounded-md border-l-2 border-transparent px-2 text-sm text-content-secondary transition hover:bg-bg-elevated hover:text-content-primary",
+            isActive && "border-l-sky-500 bg-bg-elevated text-content-primary"
+          )}
+          style={!isCollapsed ? { marginLeft: `${depth * 12}px` } : undefined}
+          title={page.title}
+        >
+          <FileText className="h-3.5 w-3.5 shrink-0" />
+          {!isCollapsed && <span className="ml-2 truncate">{page.title}</span>}
+        </Link>
+
+        {!isCollapsed && (
+          <button
+            type="button"
+            className="rounded p-1 text-content-muted opacity-0 transition hover:bg-bg-elevated hover:text-content-primary group-hover:opacity-100"
+            onClick={() => onCreateChild(page.id)}
+            aria-label={`Dodaj podstronę do ${page.title}`}
+          >
+            <Plus className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a hierarchical notes view (pages) in the workspace dashboard so users can browse, create and reorganize pages that are `type='page'`.
- Allow inline creation of pages and moving pages in a tree via drag & drop while avoiding cycles in the tree.

### Description
- Added a dedicated notes route at `/[workspaceSlug]/notes` showing recently edited pages and workspace access checks (`src/app/(dashboard)/[workspaceSlug]/notes/page.tsx`).
- Extended workspace layout to load `page` blocks and pass them to the sidebar via `pages` prop (`src/app/(dashboard)/[workspaceSlug]/layout.tsx`).
- Introduced `PageTreeItem` and `NotesTreeSidebar` components implementing a recursive tree, expand/collapse behavior, inline root/child page creation, optimistic updates and drag & drop reparenting/reordering (`src/components/notes/PageTreeItem.tsx`, `src/components/notes/NotesTreeSidebar.tsx`) and integrated the new sidebar into the main `Sidebar` (`src/components/layout/Sidebar.tsx`).
- Extended block API to support pages and tree moves: `POST /api/blocks` now supports creating `page` blocks (with `parent_block_id` and sibling `position`) and `PATCH /api/blocks/[id]` accepts `parent_block_id` (and returns `parent_block_id`) so tree changes can be persisted (`src/app/api/blocks/route.ts`, `src/app/api/blocks/[id]/route.ts`).

### Testing
- Ran type check with `npx tsc --noEmit` which passed.
- Ran `npm run lint` but it failed in this environment due to a missing `eslint-config-next/core-web-vitals` module (environment config issue, not code logic).
- Started the app with `npm run dev` to smoke-test UI; Next started but full rendering of workspace pages failed due to missing Supabase env vars in the local environment (captured a screenshot of the UI state during the run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a07af63d388330ba9d36c24da1f2ef)