### PR TITLE
Page editor: emoji icon picker, H1 title and autosave for page metadata

### DIFF
--- a/src/app/(dashboard)/[workspaceSlug]/block/[blockId]/page.tsx
+++ b/src/app/(dashboard)/[workspaceSlug]/block/[blockId]/page.tsx
@@ -12,6 +12,7 @@ interface BlockPageRouteProps {
 
 interface BlockProperties {
   title?: string;
+  icon?: string;
   status?: TaskStatus;
   due_date?: string;
   priority?: TaskPriority;
@@ -93,6 +94,7 @@ export default async function WorkspaceBlockPage({ params }: BlockPageRouteProps
       projectId={project?.id ?? undefined}
       projectName={project?.name}
       initialTitle={block.properties?.title?.trim() || "Bez tytułu"}
+      initialIcon={block.type === "page" ? block.properties?.icon : undefined}
       initialContent={Array.isArray(block.content) ? block.content : []}
       taskData={
         block.type === "task"

--- a/src/app/(dashboard)/[workspaceSlug]/notes/page.tsx
+++ b/src/app/(dashboard)/[workspaceSlug]/notes/page.tsx
@@ -15,7 +15,7 @@ interface WorkspaceRecord {
 interface RecentPage {
   id: string;
   updated_at: string;
-  properties: { title?: string } | null;
+  properties: { title?: string; icon?: string } | null;
 }
 
 export default async function NotesPage({ params }: NotesPageProps) {

--- a/src/app/api/blocks/[id]/route.ts
+++ b/src/app/api/blocks/[id]/route.ts
@@ -11,6 +11,7 @@ interface UpdateBlockPayload {
   position?: number;
   parent_block_id?: string | null;
   content?: unknown;
+  icon?: string;
 }
 
 interface BlockProperties {
@@ -19,6 +20,7 @@ interface BlockProperties {
   due_date?: string;
   priority?: "low" | "medium" | "high" | "urgent";
   assigned_to?: string;
+  icon?: string;
 }
 
 interface AccessibleBlock {
@@ -118,7 +120,8 @@ export async function PATCH(request: Request, context: { params: Promise<{ id: s
     typeof body.priority !== "undefined" ||
     typeof body.assigned_to !== "undefined" ||
     typeof body.parent_block_id !== "undefined" ||
-    typeof body.content !== "undefined";
+    typeof body.content !== "undefined" ||
+    typeof body.icon !== "undefined";
 
   if (!hasUpdatableFields) {
     return NextResponse.json({ data: null, error: "Brak danych do aktualizacji." }, { status: 400 });
@@ -158,6 +161,10 @@ export async function PATCH(request: Request, context: { params: Promise<{ id: s
       }
     }
   }
+  if (access.data.type === "page" && typeof body.icon === "string") {
+    nextProperties.icon = body.icon.trim() || "📝";
+  }
+
 
   const { data, error } = await access.supabase
     .from("blocks")

--- a/src/app/api/blocks/route.ts
+++ b/src/app/api/blocks/route.ts
@@ -135,6 +135,7 @@ export async function POST(request: Request) {
         position: nextPosition,
         properties: {
           title: body.title.trim(),
+          icon: "📝",
         },
         content: [],
       })

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -43,7 +43,7 @@ interface SidebarProps {
   workspaceId: string;
   workspaces: WorkspaceItem[];
   projects: ProjectItem[];
-  pages: Array<{ id: string; parent_block_id: string | null; position: number; properties: { title?: string } | null }>;
+  pages: Array<{ id: string; parent_block_id: string | null; position: number; properties: { title?: string; icon?: string } | null }>;
 }
 
 interface SidebarLinkProps {

--- a/src/components/notes/NotesTreeSidebar.tsx
+++ b/src/components/notes/NotesTreeSidebar.tsx
@@ -10,7 +10,7 @@ interface NotesTreeSidebarProps {
   workspaceId: string;
   workspaceSlug: string;
   isCollapsed: boolean;
-  pages: Array<{ id: string; parent_block_id: string | null; position: number; properties: { title?: string } | null }>;
+  pages: Array<{ id: string; parent_block_id: string | null; position: number; properties: { title?: string; icon?: string } | null }>;
 }
 
 export function NotesTreeSidebar({ workspaceId, workspaceSlug, isCollapsed, pages }: NotesTreeSidebarProps) {
@@ -25,6 +25,7 @@ export function NotesTreeSidebar({ workspaceId, workspaceSlug, isCollapsed, page
       parentBlockId: page.parent_block_id,
       position: page.position,
       title: page.properties?.title?.trim() || "Bez tytułu",
+      icon: page.properties?.icon?.trim() || "📝",
     }))
   );
 
@@ -104,7 +105,7 @@ export function NotesTreeSidebar({ workspaceId, workspaceSlug, isCollapsed, page
       .filter((page) => page.parentBlockId === parentBlockId)
       .reduce((max, page) => Math.max(max, page.position), 0);
 
-    setPageItems((current) => [...current, { id: tempId, title: "Nowa strona", parentBlockId, position: maxPosition + 1 }]);
+    setPageItems((current) => [...current, { id: tempId, title: "Nowa strona", icon: "📝", parentBlockId, position: maxPosition + 1 }]);
     if (parentBlockId) setExpandedPageIds((current) => new Set(current).add(parentBlockId));
 
     startTransition(async () => {
@@ -120,7 +121,7 @@ export function NotesTreeSidebar({ workspaceId, workspaceSlug, isCollapsed, page
       }
 
       const payload = (await response.json()) as {
-        data?: { id: string; parent_block_id: string | null; position: number; properties?: { title?: string } };
+        data?: { id: string; parent_block_id: string | null; position: number; properties?: { title?: string; icon?: string } };
       };
 
       if (!payload.data) {
@@ -136,6 +137,7 @@ export function NotesTreeSidebar({ workspaceId, workspaceSlug, isCollapsed, page
                 parentBlockId: payload.data!.parent_block_id,
                 position: payload.data!.position,
                 title: payload.data!.properties?.title?.trim() || "Nowa strona",
+                icon: payload.data!.properties?.icon?.trim() || "📝",
               }
             : page
         )

--- a/src/components/notes/PageTreeItem.tsx
+++ b/src/components/notes/PageTreeItem.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { ChevronDown, ChevronRight, FileText, Plus } from "lucide-react";
+import { ChevronDown, ChevronRight, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export interface SidebarPageItem {
@@ -9,6 +9,7 @@ export interface SidebarPageItem {
   title: string;
   parentBlockId: string | null;
   position: number;
+  icon?: string;
 }
 
 interface PageTreeItemProps {
@@ -74,7 +75,7 @@ export function PageTreeItem({
           style={!isCollapsed ? { marginLeft: `${depth * 12}px` } : undefined}
           title={page.title}
         >
-          <FileText className="h-3.5 w-3.5 shrink-0" />
+          <span className="shrink-0">{page.icon || "📝"}</span>
           {!isCollapsed && <span className="ml-2 truncate">{page.title}</span>}
         </Link>
 


### PR DESCRIPTION
### Motivation
- Provide a full block-note editing UX for `type='page'` including editable title, page icon and autosave so page metadata stays in sync with content.
- Surface an emoji icon picker in the page header and show page icons in the notes tree for immediate visual identification.

### Description
- Added `initialIcon` prop and `icon` state to `BlockPage`, rendered title as an H1 above the editor and added an emoji picker using `Popover` + `Button` for pages, with the icon included in the autosave payload (1500ms debounce preserved). 
- Extended `PATCH /api/blocks/[id]` to accept and persist a `icon` property for pages and made `POST /api/blocks` create pages with a default `icon: '📝'` so new pages have a consistent initial state.
- Propagated page `icon` through the routing layer (`initialIcon` in page route) and updated notes/sidebar types and components (`NotesTreeSidebar`, `PageTreeItem`, `Sidebar` and notes page) to carry and render icon metadata, plus optimistic icon handling for new pages.

### Testing
- Ran `npx tsc --noEmit` and it passed successfully.
- Ran `npm run lint` which failed in this environment due to a missing `eslint-config-next/core-web-vitals` dependency (environment-specific issue).
- Started Next dev server and captured automated browser screenshots with Playwright to exercise the new UI; server launched but routes requiring Supabase env vars produced runtime errors in this environment, limiting full authenticated visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a07d3d3ef083309d5596daa33cb2ae)