### PR TITLE
feat: add workspace member invitation flow

### DIFF
--- a/src/app/(dashboard)/[workspaceSlug]/settings/members/InviteMemberForm.tsx
+++ b/src/app/(dashboard)/[workspaceSlug]/settings/members/InviteMemberForm.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { FormEvent, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface InviteMemberFormProps {
+  workspaceId: string;
+}
+
+export function InviteMemberForm({ workspaceId }: InviteMemberFormProps) {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<"member" | "admin">("member");
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    startTransition(async () => {
+      const response = await fetch(`/api/workspace/${workspaceId}/invite`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, role }),
+      });
+
+      const payload = (await response.json()) as { error?: string };
+
+      if (!response.ok) {
+        setError(payload.error ?? "Nie udało się wysłać zaproszenia.");
+        return;
+      }
+
+      setSuccess(`Zaproszenie wysłane do ${email}.`);
+      setEmail("");
+      setRole("member");
+      router.refresh();
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-lg border border-border-subtle bg-bg-surface p-4">
+      <h2 className="text-lg font-semibold text-content-primary">Zaproś nowego członka</h2>
+      <p className="mt-1 text-sm text-content-muted">Owner może zapraszać użytkowników po emailu.</p>
+
+      <div className="mt-4 grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="invite-email">Email</Label>
+          <Input
+            id="invite-email"
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="np. anna@firma.pl"
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="invite-role">Rola</Label>
+          <select
+            id="invite-role"
+            value={role}
+            onChange={(event) => setRole(event.target.value as "member" | "admin")}
+            className="h-10 w-full rounded-md border border-border-subtle bg-bg-base px-3 text-sm text-content-primary"
+          >
+            <option value="member">member</option>
+            <option value="admin">admin</option>
+          </select>
+        </div>
+      </div>
+
+      {error && <p className="mt-3 text-sm text-red-400">{error}</p>}
+      {success && <p className="mt-3 text-sm text-emerald-400">{success}</p>}
+
+      <div className="mt-4">
+        <Button type="submit" disabled={pending}>
+          {pending ? "Wysyłanie..." : "Wyślij zaproszenie"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(dashboard)/[workspaceSlug]/settings/members/page.tsx
+++ b/src/app/(dashboard)/[workspaceSlug]/settings/members/page.tsx
@@ -1,0 +1,99 @@
+import { redirect } from "next/navigation";
+import { createServerClient } from "@/lib/supabase/server";
+import { InviteMemberForm } from "./InviteMemberForm";
+
+interface MembersPageProps {
+  params: Promise<{ workspaceSlug: string }>;
+}
+
+interface MemberRow {
+  user_id: string;
+  role: "owner" | "admin" | "member";
+  invited_at: string | null;
+  accepted_at: string | null;
+}
+
+export default async function MembersSettingsPage({ params }: MembersPageProps) {
+  const { workspaceSlug } = await params;
+  const supabase = await createServerClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { data: workspace } = await supabase
+    .from("workspaces")
+    .select("id, name, slug")
+    .eq("slug", workspaceSlug)
+    .single();
+
+  if (!workspace) {
+    redirect("/");
+  }
+
+  const { data: myMembership } = await supabase
+    .from("workspace_members")
+    .select("role")
+    .eq("workspace_id", workspace.id)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!myMembership) {
+    redirect("/");
+  }
+
+  const { data: members } = await supabase
+    .from("workspace_members")
+    .select("user_id, role, invited_at, accepted_at")
+    .eq("workspace_id", workspace.id)
+    .order("invited_at", { ascending: true })
+    .returns<MemberRow[]>();
+
+  return (
+    <div className="mx-auto w-full max-w-5xl px-8 py-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-content-primary">Członkowie workspace</h1>
+        <p className="mt-1 text-sm text-content-muted">{workspace.name} — zarządzanie zaproszeniami i rolami.</p>
+      </div>
+
+      {myMembership.role === "owner" && <div className="mt-6"><InviteMemberForm workspaceId={workspace.id} /></div>}
+
+      <section className="mt-6 rounded-lg border border-border-subtle bg-bg-surface">
+        <div className="border-b border-border-subtle px-4 py-3">
+          <h2 className="text-sm font-medium text-content-primary">Lista członków</h2>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-left text-sm">
+            <thead className="bg-bg-subtle text-content-muted">
+              <tr>
+                <th className="px-4 py-3 font-medium">User ID</th>
+                <th className="px-4 py-3 font-medium">Rola</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 font-medium">Zaproszono</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(members ?? []).map((member) => (
+                <tr key={member.user_id} className="border-t border-border-subtle">
+                  <td className="px-4 py-3 font-mono text-xs text-content-secondary">{member.user_id}</td>
+                  <td className="px-4 py-3 text-content-primary">{member.role}</td>
+                  <td className="px-4 py-3 text-content-secondary">
+                    {member.accepted_at ? "accepted" : "pending"}
+                  </td>
+                  <td className="px-4 py-3 text-content-secondary">
+                    {member.invited_at ? new Date(member.invited_at).toLocaleString("pl-PL") : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/api/workspace/[id]/invite/route.ts
+++ b/src/app/api/workspace/[id]/invite/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from "next/server";
+import { createServerClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+type InvitePayload = {
+  email?: string;
+  role?: "member" | "admin";
+};
+
+export async function POST(request: Request, context: { params: Promise<{ id: string }> }) {
+  const { id: workspaceId } = await context.params;
+  const supabase = await createServerClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ data: null, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = (await request.json()) as InvitePayload;
+  const email = body.email?.trim().toLowerCase();
+  const role = body.role;
+
+  if (!email || !role || !["member", "admin"].includes(role)) {
+    return NextResponse.json(
+      { data: null, error: "Pola email i rola (member/admin) są wymagane." },
+      { status: 400 }
+    );
+  }
+
+  const { data: ownerMembership, error: ownerError } = await supabase
+    .from("workspace_members")
+    .select("role")
+    .eq("workspace_id", workspaceId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (ownerError || ownerMembership?.role !== "owner") {
+    return NextResponse.json(
+      { data: null, error: "Tylko owner może zapraszać członków do workspace." },
+      { status: 403 }
+    );
+  }
+
+  const { data: workspace, error: workspaceError } = await supabase
+    .from("workspaces")
+    .select("slug")
+    .eq("id", workspaceId)
+    .single();
+
+  if (workspaceError || !workspace) {
+    return NextResponse.json({ data: null, error: "Workspace nie istnieje." }, { status: 404 });
+  }
+
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    return NextResponse.json(
+      { data: null, error: "Brak SUPABASE_SERVICE_ROLE_KEY w środowisku." },
+      { status: 500 }
+    );
+  }
+
+  const admin = createAdminClient();
+  const { data: inviteData, error: inviteError } = await admin.auth.admin.inviteUserByEmail(email, {
+    redirectTo: `${new URL(request.url).origin}/auth/callback?next=/${workspace.slug}/settings/members`,
+  });
+
+  if (inviteError || !inviteData.user) {
+    return NextResponse.json(
+      { data: null, error: inviteError?.message ?? "Nie udało się wysłać zaproszenia." },
+      { status: 500 }
+    );
+  }
+
+  const { error: membershipError } = await admin
+    .from("workspace_members")
+    .upsert(
+      {
+        workspace_id: workspaceId,
+        user_id: inviteData.user.id,
+        role,
+        invited_at: new Date().toISOString(),
+        accepted_at: null,
+      },
+      { onConflict: "workspace_id,user_id" }
+    );
+
+  if (membershipError) {
+    return NextResponse.json(
+      { data: null, error: "Zaproszenie wysłane, ale nie udało się zapisać membership." },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ data: { userId: inviteData.user.id, email, role }, error: null }, { status: 201 });
+}

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -45,6 +45,19 @@ export async function GET(request: NextRequest) {
     const { error } = await supabase.auth.exchangeCodeForSession(code);
 
     if (!error) {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (user) {
+        await supabase
+          .from("workspace_members")
+          .update({ accepted_at: new Date().toISOString() })
+          .eq("user_id", user.id)
+          .is("accepted_at", null)
+          .neq("role", "owner");
+      }
+
       return NextResponse.redirect(`${origin}${next}`);
     }
   }

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,0 +1,14 @@
+import { createClient } from "@supabase/supabase-js";
+
+export function createAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    }
+  );
+}


### PR DESCRIPTION
### Motivation

- Enable workspace owners to invite users by email and manage memberships from the workspace settings page.
- Persist invitations in `workspace_members` with an `accepted_at` lifecycle so pending memberships are visible and can be accepted.

### Description

- Added members settings page at `/:workspaceSlug/settings/members` showing a list of members with `role`, `invited_at` and `accepted_at`, and access checks for logged-in workspace members (`src/app/(dashboard)/[workspaceSlug]/settings/members/page.tsx`).
- Implemented invitation form with `email` + `role` (member/admin) for owners that posts to `POST /api/workspace/[id]/invite` (`src/app/(dashboard)/[workspaceSlug]/settings/members/InviteMemberForm.tsx`).
- Added route handler `POST /api/workspace/[id]/invite` which verifies the requester is the workspace `owner`, sends a Supabase Auth invite via the service role client, and upserts a `workspace_members` record with `accepted_at = null` (`src/app/api/workspace/[id]/invite/route.ts`).
- Created `createAdminClient()` util to build a Supabase admin client using `SUPABASE_SERVICE_ROLE_KEY` (`src/lib/supabase/admin.ts`).
- Updated the auth callback flow to mark pending `workspace_members` for the logged-in user as accepted by setting `accepted_at` after successful session exchange (`src/app/auth/callback/route.ts`).

### Testing

- Ran `npm run build` and the Next.js production build completed successfully.
- Ran `npm run lint` which failed in this environment due to a missing dev dependency (`eslint-config-next/core-web-vitals`).
- Started the dev server and executed an automated Playwright script to capture the members settings page, which produced a screenshot but the runtime reported missing Supabase env vars in this environment (expected when `NEXT_PUBLIC_SUPABASE_URL` and keys are not provided).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a07ecfee088330892cc0307c73a4bb)